### PR TITLE
Update URL references to IntersectMBO repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,13 +7,13 @@ Add your description here, if it fixes a particular issue please provide a [link
 - [ ] Commit sequence broadly makes sense
 - [ ] Commits have useful messages
 - [ ] New tests are added if needed and existing tests are updated
-- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
+- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
 - [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
 - [ ] Self-reviewed the diff
 
 # Migrations
 
-- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
+- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
 - [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
 - [ ] Resyncing and running the migrations provided will result in the same database semantically
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,20 @@
 # General reviewers per PR
-* @input-output-hk/core-tech-dbsync
+* @IntersectMBO/core-tech-dbsync
 
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence
 
 # /doc folder and README.* needs to be owned by @docs-access
-doc                          @input-output-hk/docs-access @input-output-hk/core-tech-dbsync
-Readme.*                     @input-output-hk/docs-access @input-output-hk/core-tech-dbsync
-CONTRIBUTING.rst             @input-output-hk/docs-access @input-output-hk/core-tech-dbsync
+doc                          @input-output-hk/docs-access @IntersectMBO/core-tech-dbsync
+Readme.*                     @input-output-hk/docs-access @IntersectMBO/core-tech-dbsync
+CONTRIBUTING.rst             @input-output-hk/docs-access @IntersectMBO/core-tech-dbsync
 
 # DevOps
-.buildkite                   @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-.github                      @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-/config                      @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-nix                          @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-*.nix                        @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-flake.lock                   @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-bors.toml                    @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-docker-compose.yml           @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-scripts/postgresql-setup.sh  @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+.github                      @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+/config                      @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+nix                          @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+*.nix                        @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+flake.lock                   @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+bors.toml                    @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+docker-compose.yml           @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+scripts/postgresql-setup.sh  @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ deployments.
 
 On how to set up Nix for ``cardano-db-sync`` development, please see `Building Cardano
 Node with nix
-<https://github.com/input-output-hk/cardano-node/tree/master/doc/getting-started/building-the-node-using-nix.md>`_.
+<https://github.com/IntersectMBO/cardano-node/tree/master/doc/getting-started/building-the-node-using-nix.md>`_.
 
 Roles and Responsibilities
 ==========================
@@ -77,6 +77,6 @@ Releasing a New Version
 
 See `<doc/release-process.md>`__
 
-.. _CODEOWNERS: https://github.com/input-output-hk/cardano-db-sync/blob/master/CODEOWNERS
-.. _cardano-haskell-packages: https://github.com/input-output-hk/cardano-haskell-packages
+.. _CODEOWNERS: https://github.com/IntersectMBO/cardano-db-sync/blob/master/CODEOWNERS
+.. _cardano-haskell-packages: https://github.com/IntersectMBO/cardano-haskell-packages
 .. _fourmolu: https://github.com/fourmolu/fourmolu

--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,7 @@ above is met).
 
 Install db-sync with one of the following methods:
 
- * [Static Binaries](https://github.com/input-output-hk/cardano-db-sync/releases/latest)
+ * [Static Binaries](https://github.com/IntersectMBO/cardano-db-sync/releases/latest)
  * [Installing with Nix][InstallingNix]
  * [Installing from Source][Installing]
  * [Docker][Docker]

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 repository cardano-haskell-packages
-  url: https://input-output-hk.github.io/cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
   secure: True
   root-keys:
     3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
@@ -73,7 +73,7 @@ allow-newer:
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-node
+  location: https://github.com/IntersectMBO/cardano-node
   tag: 34d89af65439db92293b88967c299c20692abc1c
   --sha256: sha256-pVUWfzVnM4RvpFlJNH2ZmWPZzmkGT1Ty8B1p7NFh69M=
   subdir:

--- a/cardano-chain-gen/cardano-chain-gen.cabal
+++ b/cardano-chain-gen/cardano-chain-gen.cabal
@@ -4,8 +4,8 @@ name:                   cardano-chain-gen
 version:                13.2.0.0
 synopsis:               A fake chain generator for testing cardano DB sync.
 description:            A fake chain generator for testing cardano DB sync.
-homepage:               https://github.com/input-output-hk/cardano-db-sync
-bug-reports:            https://github.com/input-output-hk/cardano-db-sync/issues
+homepage:               https://github.com/IntersectMBO/cardano-db-sync
+bug-reports:            https://github.com/IntersectMBO/cardano-db-sync/issues
 license:                Apache-2.0
 license-file:           LICENSE
 author:                 IOHK Engineering Team

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/PoolAndSmash.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/PoolAndSmash.hs
@@ -74,7 +74,7 @@ poolReg =
   where
     testLabel = "poolReg-alonzo"
 
--- Issue https://github.com/input-output-hk/cardano-db-sync/issues/997
+-- Issue https://github.com/IntersectMBO/cardano-db-sync/issues/997
 nonexistantPoolQuery :: IOManager -> [(Text, Text)] -> Assertion
 nonexistantPoolQuery =
   withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Other.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Other.hs
@@ -147,7 +147,7 @@ poolReg =
   where
     testLabel = "poolReg"
 
--- Issue https://github.com/input-output-hk/cardano-db-sync/issues/997
+-- Issue https://github.com/IntersectMBO/cardano-db-sync/issues/997
 nonexistantPoolQuery :: IOManager -> [(Text, Text)] -> Assertion
 nonexistantPoolQuery =
   withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Reward.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Reward.hs
@@ -109,7 +109,7 @@ simpleRewards =
 
 -- This test is the same as the previous, but in Shelley era. Rewards result
 -- should be different because of the old Shelley bug.
--- https://github.com/input-output-hk/cardano-db-sync/issues/959
+-- https://github.com/IntersectMBO/cardano-db-sync/issues/959
 --
 -- The differenece in rewards is triggered when a reward address of a pool A
 -- delegates to a pool B and is not an owner of pool B. In this case it receives

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Other.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Other.hs
@@ -137,7 +137,7 @@ poolReg =
   where
     testLabel = "conwayPoolReg"
 
--- Issue https://github.com/input-output-hk/cardano-db-sync/issues/997
+-- Issue https://github.com/IntersectMBO/cardano-db-sync/issues/997
 nonexistentPoolQuery :: IOManager -> [(Text, Text)] -> Assertion
 nonexistentPoolQuery =
   withFullConfig conwayConfigDir testLabel $ \interpreter mockServer dbSync -> do

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Reward.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Reward.hs
@@ -80,7 +80,7 @@ simpleRewards =
 
 -- This test is the same as the previous, but in Shelley era. Rewards result
 -- should be different because of the old Shelley bug.
--- https://github.com/input-output-hk/cardano-db-sync/issues/959
+-- https://github.com/IntersectMBO/cardano-db-sync/issues/959
 --
 -- The differenece in rewards is triggered when a reward address of a pool A
 -- delegates to a pool B and is not an owner of pool B. In this case it receives

--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -12,9 +12,9 @@ It is advised to resync from genesis when using a new version a or b.
 
 Some useful links (adjust the numbers to the correct tag):
 
-- Changelog: https://github.com/input-output-hk/cardano-db-sync/blob/sancho-2-0-0/cardano-db-sync/CHANGELOG.md#13200
-- Schema docs https://github.com/input-output-hk/cardano-db-sync/blob/sancho-2-0-0/doc/schema.md
-- Postgres migrations https://github.com/input-output-hk/cardano-db-sync/tree/sancho-2-0-0/schema
+- Changelog: https://github.com/IntersectMBO/cardano-db-sync/blob/sancho-2-0-0/cardano-db-sync/CHANGELOG.md#13200
+- Schema docs https://github.com/IntersectMBO/cardano-db-sync/blob/sancho-2-0-0/doc/schema.md
+- Postgres migrations https://github.com/IntersectMBO/cardano-db-sync/tree/sancho-2-0-0/schema
 
 In the schema docs, you can search for `13.2` or `Conway` for schema changes from the previous official release.
 
@@ -57,7 +57,7 @@ In the schema docs, you can search for `13.2` or `Conway` for schema changes fro
 - is compatible with node-8.3-pre. There are no schema changes over sancho-1-0-0.
 
 ### sancho-1.0.0
-The schema is quite close to the [initial design](https://github.com/input-output-hk/cardano-db-sync/blob/conway-schema-design-13.2/doc/schema.md). You may find some differences: ie the `param_proposals` and `epoch_param` are not extended yet,
+The schema is quite close to the [initial design](https://github.com/IntersectMBO/cardano-db-sync/blob/conway-schema-design-13.2/doc/schema.md). You may find some differences: ie the `param_proposals` and `epoch_param` are not extended yet,
 Some tables/fields are created but are not populated yet: `anchor_offline_data`, `anchor_offline_fetch_error` , `drep_distr` , `governance_action.x_epoch` , `delegation_vote.redeemer_id`
 
 ### sancho-0.0.0
@@ -125,10 +125,10 @@ It's very early stage and is missing all Conway specific feautures and some Shel
 * Bump to the latest node release.
 
 ## 13.0.3
-* Integrated the fix for the missused minfee function in ledger (https://github.com/input-output-hk/cardano-ledger/pull/2938)
+* Integrated the fix for the missused minfee function in ledger (https://github.com/IntersectMBO/cardano-ledger/pull/2938)
 
 ## 13.0.2
-* Integrated the fix of the obsolete check in the new 'Praos' protocol (https://github.com/input-output-hk/ouroboros-network/pull/3891)
+* Integrated the fix of the obsolete check in the new 'Praos' protocol (https://github.com/IntersectMBO/ouroboros-network/pull/3891)
 
 ## 13.0.1
 * Ensure Babbage TxOut decoder can't fail due to malformed Ptr. This bug manifests itself if db-sync is running in the Babbage era and shuts down, it has to re-sync from an Alonzo snapshot, or from Genesis if it doesn't exist. (#1181)

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -36,7 +36,7 @@ main = do
     stateDirErrorMsg :: [Char]
     stateDirErrorMsg =
       "Error: If not using --state-dir then make sure to have --disable-ledger. "
-        <> "For more details view https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/syncing-and-rollbacks.md#ledger-state"
+        <> "For more details view https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/syncing-and-rollbacks.md#ledger-state"
 
     run :: SyncNodeParams -> IO ()
     run prms = do

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -5,8 +5,8 @@ version:                13.2.0.0
 synopsis:               The Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database.
-homepage:               https://github.com/input-output-hk/cardano-db-sync
-bug-reports:            https://github.com/input-output-hk/cardano-db-sync/issues
+homepage:               https://github.com/IntersectMBO/cardano-db-sync
+bug-reports:            https://github.com/IntersectMBO/cardano-db-sync/issues
 license:                Apache-2.0
 license-file:           LICENSE
 author:                 IOHK Engineering Team

--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -367,7 +367,7 @@ mkSyncEnv trce backend syncOptions protoInfo nw nwMagic systemStart syncNP ranMi
       (Just _, False) -> do
         logWarning trce $
           "Using `--disable-ledger` doesn't require having a --state-dir."
-            <> " For more details view https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/configuration.md#--disable-ledger"
+            <> " For more details view https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/configuration.md#--disable-ledger"
         NoLedger <$> mkNoLedgerEnv trce protoInfo nw systemStart
       -- This won't ever call because we error out this combination at parse time
       (Nothing, True) -> NoLedger <$> mkNoLedgerEnv trce protoInfo nw systemStart

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Witness.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Witness.hs
@@ -14,10 +14,9 @@ import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
 
--- Cargo culted from ledger-specs. Written by Tim Sheard and PRed in
--- https://github.com/input-output-hk/cardano-ledger-specs/pull/2173
--- Even once it is merged, will need to wait until the node moves to a
--- version that this feature.
+-- Cargo culted from ledger. Written by Tim Sheard and PRed in
+-- https://github.com/IntersectMBO/cardano-ledger/pull/2173 Even once it is merged, will
+-- need to wait until the node moves to a version that this feature.
 
 -- | Evidence that a valid (predefined) crypto exists
 data Evidence c where

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -751,7 +751,7 @@ insertPoolRegister _tracer cache isMember network (EpochNo epoch) blkId txId idx
           pure $ if otherUpdates then 3 else 2
 
     -- Ignore the network in the `RewardAcnt` and use the provided one instead.
-    -- This is a workaround for https://github.com/input-output-hk/cardano-db-sync/issues/546
+    -- This is a workaround for https://github.com/IntersectMBO/cardano-db-sync/issues/546
     adjustNetworkTag :: Ledger.RewardAcnt StandardCrypto -> Ledger.RewardAcnt StandardCrypto
     adjustNetworkTag (Shelley.RewardAcnt _ cred) = Shelley.RewardAcnt network cred
 

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/OffChain/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/OffChain/Types.hs
@@ -76,7 +76,7 @@ instance ToSchema PoolOffChainMetadata
 
 -- -------------------------------------------------------------------------------------------------
 
--- Copied from https://github.com/input-output-hk/cardano-node/pull/1299
+-- Copied from https://github.com/IntersectMBO/cardano-node/pull/1299
 
 -- | Parse and validate the stake pool metadata name from a JSON object.
 --

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Util.hs
@@ -44,7 +44,7 @@ safeDecodeToJson tracer tracePrefix x = do
       -- We have to insert
       pure Nothing
     Right json ->
-      -- See https://github.com/input-output-hk/cardano-db-sync/issues/297
+      -- See https://github.com/IntersectMBO/cardano-db-sync/issues/297
       if containsUnicodeNul json
         then do
           liftIO $ logWarning tracer $ tracePrefix <> ": dropped due to a Unicode NUL character."

--- a/cardano-db-sync/src/Cardano/DbSync/StateQuery.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/StateQuery.hs
@@ -30,7 +30,7 @@ import Ouroboros.Consensus.HardFork.History.Qry (
 -- -------------------------------------------------------------------------------------------------
 
 -- TODO: Switch back to the old version of this when this is fixed:
--- https://github.com/input-output-hk/cardano-db-sync/issues/276
+-- https://github.com/IntersectMBO/cardano-db-sync/issues/276
 querySlotDetails :: SystemStart -> SlotNo -> Qry SlotDetails
 querySlotDetails start absSlot = do
   absTime <- qryFromExpr $

--- a/cardano-db-tool/cardano-db-tool.cabal
+++ b/cardano-db-tool/cardano-db-tool.cabal
@@ -5,8 +5,8 @@ version:                13.2.0.0
 synopsis:               Utilities to manage the cardano-db-sync databases.
 description:            Utilities and executable, used to manage and validate the
                         PostgreSQL db and the ledger database of the cardano-db-sync node
-homepage:               https://github.com/input-output-hk/cardano-db-sync
-bug-reports:		        https://github.com/input-output-hk/cardano-db-sync/issues
+homepage:               https://github.com/IntersectMBO/cardano-db-sync
+bug-reports:            https://github.com/IntersectMBO/cardano-db-sync/issues
 license:                Apache-2.0
 license-file:           LICENSE
 author:                 IOHK Engineering Team

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -5,8 +5,8 @@ version:                13.2.0.0
 synopsis:               A base PostgreSQL component for the cardano-db-sync node.
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.
-homepage:               https://github.com/input-output-hk/cardano-db-sync
-bug-reports:		        https://github.com/input-output-hk/cardano-db-sync/issues
+homepage:               https://github.com/IntersectMBO/cardano-db-sync
+bug-reports:            https://github.com/IntersectMBO/cardano-db-sync/issues
 license:                Apache-2.0
 license-file:           LICENSE
 author:                 IOHK Engineering Team

--- a/cardano-db/test/cardano-db-test.cabal
+++ b/cardano-db/test/cardano-db-test.cabal
@@ -5,8 +5,8 @@ version:                13.2.0.0
 synopsis:               Tests for the base functionality of the cardano-db library
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.
-homepage:               https://github.com/input-output-hk/cardano-db-sync
-bug-reports:            https://github.com/input-output-hk/cardano-db-sync/issues
+homepage:               https://github.com/IntersectMBO/cardano-db-sync
+bug-reports:            https://github.com/IntersectMBO/cardano-db-sync/issues
 license:                Apache-2.0
 license-file:           LICENSE
 author:                 IOHK Engineering Team

--- a/cardano-smash-server/cardano-smash-server.cabal
+++ b/cardano-smash-server/cardano-smash-server.cabal
@@ -4,9 +4,9 @@ name:                   cardano-smash-server
 version:                13.2.0.0
 synopsis:               The Cardano smash server
 description:            Please see the README on GitHub at
-                        <https://github.com/input-output-hk/cardano-db-sync/cardano-smash-server/#readme>
-homepage:               https://github.com/input-output-hk/cardano-db-sync
-bug-reports:            https://github.com/input-output-hk/cardano-db-sync/issues
+                        <https://github.com/IntersectMBO/cardano-db-sync/cardano-smash-server/#readme>
+homepage:               https://github.com/IntersectMBO/cardano-db-sync
+bug-reports:            https://github.com/IntersectMBO/cardano-db-sync/issues
 license:                Apache-2.0
 license-file:           LICENSE
 author:                 IOHK Engineering Team
@@ -113,6 +113,3 @@ executable cardano-smash-server
                       , cardano-prelude
                       , optparse-applicative
                       , text
-
-
-

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Impl.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Impl.hs
@@ -70,7 +70,7 @@ todoSwagger =
             Just $
               License
                 { _licenseName = "APACHE2"
-                , _licenseUrl = Just $ URL "https://github.com/input-output-hk/cardano-db-sync/blob/master/LICENSE"
+                , _licenseUrl = Just $ URL "https://github.com/IntersectMBO/cardano-db-sync/blob/master/LICENSE"
                 }
         , _infoVersion = smashVersion
         }

--- a/doc/building-running.md
+++ b/doc/building-running.md
@@ -7,7 +7,7 @@ that is unsupported.
 
 Running the db sync node will require Nix and either multiple terminals or a multi terminal
 emulator like GNU Screen or TMux.
-Setup [IOHK binary cache](https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md#iohk-binary-cache)
+Setup [IOHK binary cache](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md#iohk-binary-cache)
 to avoid several hours of build time.
 
 The db sync node is designed to work with a locally running Cardano Node. The two git repositories need to be checked out so that
@@ -29,15 +29,15 @@ Regular users should almost never attempt building and running from the `master`
 they should build and run the latest release tag. The tags can be listed using the `git tag`
 command. Pre-release tags (eg things like `12.0.0-preX`) should also be avoided in most cases.
 ```
-git clone https://github.com/input-output-hk/cardano-node
+git clone https://github.com/IntersectMBO/cardano-node
 cd cardano-node
 git checkout <latest-official-tag> -b tag-<latest-official-tag>
 nix run .#mainnet/node
 ```
 
 More detailed instructions on GHC, Cabal, libraries and `cardano-node` setup can be found here:
-- [Installing Cardano Node from source](https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/install.md)
-- [Building Cardano Node with nix](https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md)
+- [Installing Cardano Node from source](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/install.md)
+- [Building Cardano Node with nix](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md)
 
 ### Set up and run the db-sync node
 
@@ -58,7 +58,7 @@ make install
 - with cabal:
 
 ```
-git clone https://github.com/input-output-hk/cardano-db-sync
+git clone https://github.com/IntersectMBO/cardano-db-sync
 cd cardano-db-sync
 PGPASSFILE=config/pgpass-mainnet scripts/postgresql-setup.sh --createdb
 git checkout <latest-official-tag> -b tag-<latest-official-tag>
@@ -85,7 +85,7 @@ when running cabal build
 - with nix:
 
 ```
-git clone https://github.com/input-output-hk/cardano-db-sync
+git clone https://github.com/IntersectMBO/cardano-db-sync
 cd cardano-db-sync
 git checkout <latest-official-tag> -b tag-<latest-official-tag>
 nix build -v .#cardano-db-sync -o db-sync-node

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -8,7 +8,7 @@ Regular users should almost never attempt building and running from the `master`
 they should build and run the latest release tag. The tags can be listed using the `git tag`
 command. Pre-release tags (eg things like `12.0.0-preX`) should also be avoided in most cases.
 ```
-git clone git@github.com:input-output-hk/cardano-db-sync.git
+git clone git@github.com:IntersectMBO/cardano-db-sync.git
 cd cardano-db-sync
 git checkout <latest-official-tag> -b tag-<latest-official-tag>
 ```
@@ -27,8 +27,8 @@ The PostgreSQL database is exposed on localhost port `5432`
 
 ### To change PostgreSQL settings:
 
-Release `13.1.0.0` introduced new flag `POSTGRES_ARGS` inside 
-[docker-compose.yml](https://github.com/input-output-hk/cardano-db-sync/blob/master/docker-compose.yml) file wih
+Release `13.1.0.0` introduced new flag `POSTGRES_ARGS` inside
+[docker-compose.yml](https://github.com/IntersectMBO/cardano-db-sync/blob/master/docker-compose.yml) file wih
 reccomended default values for `maintenance_work_mem` and `max_parallel_maintenance_workers` parameters.
 
 - default start
@@ -80,7 +80,7 @@ docker run \
   -v $PWD/config/network/mainnet/cardano-db-sync:/config \
   -v $PWD/config/network/mainnet/genesis:/genesis \
   -v $PWD/node-ipc:/node-ipc \
-  ghcr.io/input-output-hk/cardano-db-sync:13.1.1.2-docker \
+  ghcr.io/IntersectMBO/cardano-db-sync:13.1.1.2-docker \
     run --config /config/config.yaml --socket-path /node-ipc/node.socket # command
 ```
 
@@ -95,7 +95,7 @@ docker load -i ./result
 
 Restoring a database by running from gensis can take a number of hours, snapshots are provided for
 Mainnet to restore the postgres database. See the
-[latest releases](https://github.com/input-output-hk/cardano-db-sync/releases) for a recent snapshot
+[latest releases](https://github.com/IntersectMBO/cardano-db-sync/releases) for a recent snapshot
 matched with the `cardano-db-sync` version.
 
 To download and restore a snapshot include `RESTORE_SNAPSHOT`:

--- a/doc/installing-with-nix.md
+++ b/doc/installing-with-nix.md
@@ -9,8 +9,8 @@ build Cardano DB Sync.
 This guide assumes you have the following tools:
 
  * [Nix](https://nixos.org/download.html)
- * [Cardano Node](https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md)
- 
+ * [Cardano Node](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md)
+
 Nix will handle all other dependencies.
 
 Create a working directory for your builds:
@@ -52,12 +52,12 @@ Enter the working directory for your builds:
 cd ~/src
 ```
 
-Find the latest release here: https://github.com/input-output-hk/cardano-db-sync/releases
+Find the latest release here: https://github.com/IntersectMBO/cardano-db-sync/releases
 
 Check out the latest release version:
 
 ```bash
-git clone https://github.com/input-output-hk/cardano-db-sync.git
+git clone https://github.com/IntersectMBO/cardano-db-sync.git
 cd cardano-db-sync
 git fetch --all --tags
 git checkout tags/<VERSION>

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -5,20 +5,20 @@
 This guide assumes you have the following tools:
 
  * [Git](https://git-scm.com/download)
- * [Cardano Node](https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/install.md)
+ * [Cardano Node](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/install.md)
  * [Postgres Development Libraries (libpq)](https://www.postgresql.org/download/)
  * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
- 
+
 In addition, Cardano DB Sync requires the following software (instructions below):
 
  * [GHC](https://www.haskell.org/ghcup/install/) >= 8.10.7
  * [Cabal](https://www.haskell.org/ghcup/install/) >= 3.10.1.0
- * [libsodium-vrf](https://github.com/input-output-hk/libsodium)
+ * [libsodium-vrf](https://github.com/IntersectMBO/libsodium)
  * [secp256k1](https://github.com/bitcoin-core/secp256k1)
  * [blst](https://github.com/supranational/blst)
- 
+
  macOS:
- 
+
 * [x-code](https://developer.apple.com/xcode/resources/)
 
 Create a working directory for your builds:
@@ -57,7 +57,7 @@ It should print a path of this shape: `/home/<user>/.ghcup/bin/cabal`.
 
 ### Install Sodium
 
-Cardano uses a [fork](https://github.com/input-output-hk/libsodium) of `libsodium` which
+Cardano uses a [fork](https://github.com/IntersectMBO/libsodium) of `libsodium` which
 exposes some internal functions and adds some other new functions.
 
 Enter a working directory for your builds:
@@ -76,7 +76,7 @@ REV=$(curl -L https://github.com/input-output-hk/iohk-nix/releases/latest/downlo
 Checkout libsodium:
 
 ```bash
-git clone https://github.com/input-output-hk/libsodium
+git clone https://github.com/IntersectMBO/libsodium
 cd libsodium
 git checkout $REV
 ```
@@ -218,12 +218,12 @@ Enter the working directory for your builds:
 cd ~/src
 ```
 
-Find the latest release here: https://github.com/input-output-hk/cardano-db-sync/releases
+Find the latest release here: https://github.com/IntersectMBO/cardano-db-sync/releases
 
 Check out the latest release version:
 
 ```bash
-git clone https://github.com/input-output-hk/cardano-db-sync.git
+git clone https://github.com/IntersectMBO/cardano-db-sync.git
 cd cardano-db-sync
 git fetch --all --tags
 git checkout tags/<VERSION>

--- a/doc/interesting-queries.md
+++ b/doc/interesting-queries.md
@@ -611,7 +611,7 @@ select distinct on(block.hash) block.hash as block_hash , epoch_no, tx_count, po
 
 ### Find all incorrect entries in `epoch` table
 
-In [issue #1457](https://github.com/input-output-hk/cardano-db-sync/issues/1457) it was pointed out
+In [issue #1457](https://github.com/IntersectMBO/cardano-db-sync/issues/1457) it was pointed out
 that some entries in the epoch table were incorrect. These incorrect entries can be found using:
 ```
 select b.epoch_no, e.epoch_blk_count, e.epoch_tx_count, b.block_block_count, b.block_tx_count
@@ -629,4 +629,4 @@ them.
 ---
 
 
-[Query.hs]: https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db/src/Cardano/Db/Query.hs
+[Query.hs]: https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db/src/Cardano/Db/Query.hs

--- a/doc/smash.md
+++ b/doc/smash.md
@@ -68,7 +68,7 @@ SMASH records and serves the following subset of information:
 * homepage
 * short description
 
-More information about the pool metadata (the `PoolMetaData` record) can be found [here](https://github.com/input-output-hk/cardano-ledger-specs/blob/4458fdba7e2211f63e7f28ecd3f9b55b02eee071/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs#L62)
+More information about the pool metadata (the `PoolMetaData` record) can be found [here](https://github.com/IntersectMBO/cardano-ledger/blob/4458fdba7e2211f63e7f28ecd3f9b55b02eee071/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs#L62)
 
 Stake pool metadata information can be also found in [The mainnet metadata Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/build/790053/download/1/delegation_design_spec.pdf) section 4.2 Stake Pool Metadata, p.30.
 
@@ -107,7 +107,7 @@ PGPASSFILE=config/pgpass-mainnet db-sync-node/bin/cardano-db-sync \
     --schema-dir schema/
 ```
 
-see https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/building-running.md for more info on how
+see https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/building-running.md for more info on how
 to run cardano-db-sync.
 
 Finally you can then run ``smash-server`` using e.g:

--- a/doc/state-snapshot.md
+++ b/doc/state-snapshot.md
@@ -27,7 +27,7 @@ Currently (at epoch 269), creating a snapshot takes about 15 minutes and restori
 * Creating and restoring snapshots requires significant amounts of free disk space (at epoch 269
   it required about 10G). If there is insufficient disk space, `gzip` can give some odd error
   messages.
-* node tip should be ahead of the snapshot point during restoration otherwise `cardano-db-sync` will 
+* node tip should be ahead of the snapshot point during restoration otherwise `cardano-db-sync` will
   roll back to genesis
 
 # Creating a Snapshot
@@ -60,4 +60,4 @@ syncing from the block number listed in the state snapshot file name.
 # Mainnet Snapshots Location
 
 `Mainnet` snapshots can be found [here](https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#).
-They are also linked from the `cardano-db-sync` [releases page](https://github.com/input-output-hk/cardano-db-sync/releases)
+They are also linked from the `cardano-db-sync` [releases page](https://github.com/IntersectMBO/cardano-db-sync/releases)

--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1701085773,
-        "narHash": "sha256-R4931htVMyz67VAOrnucHwJqg9pg7ugQ6Us2gIpeD8A=",
-        "owner": "input-output-hk",
+        "lastModified": 1702906471,
+        "narHash": "sha256-br+hVo3R6nfmiSEPXcLKhIX4Kg5gcK2PjzjmvQsuUp8=",
+        "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "cb16e4a295c594cd1d5f02008e4dd03eb6061d25",
+        "rev": "48a359ac3f1d437ebaa91126b20e15a65201f004",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "repo",
         "repo": "cardano-haskell-packages",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       flake = false;
     };
     CHaP = {
-      url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
+      url = "github:IntersectMBO/cardano-haskell-packages?ref=repo";
       flake = false;
     };
     cardano-parts = {
@@ -155,7 +155,7 @@
                 (compiler-nix-name: { inherit compiler-nix-name; });
 
             inputMap = {
-              "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
+              "https://chap.intersectmbo.org/" = inputs.CHaP;
             };
 
             shell.tools = {


### PR DESCRIPTION
# Description

Update all references to repositories that have moved to IntersectMBO

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
