### PR TITLE
Flag to keep specified Tx Metadata by key names

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
@@ -268,6 +268,7 @@ mkSyncNodeParams staticDir mutableDir CommandLineArgs {..} = do
       , enpHasShelley = True
       , enpHasMultiAssets = claHasMultiAssets
       , enpHasMetadata = claHasMetadata
+      , enpKeepMetadataNames = []
       , enpHasPlutusExtra = True
       , enpHasGov = True
       , enpHasOffChainPoolData = True

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -229,10 +229,11 @@ pSlotNo =
           <> Opt.metavar "WORD"
       )
 
-pKeepTxMetadata :: Parser [Text]
+pKeepTxMetadata :: Parser [Word64]
 pKeepTxMetadata =
   Opt.many
-    ( Opt.strOption
+    ( Opt.option
+        Opt.auto
         ( Opt.long "keep-tx-metadata"
             <> Opt.help "Insert a specific set of tx metadata, based on the tx metadata key names"
         )

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -7,6 +7,7 @@ import Cardano.DbSync.Config
 import Cardano.DbSync.Metrics (withMetricSetters)
 import Cardano.Prelude
 import Cardano.Slotting.Slot (SlotNo (..))
+import Data.List.Split (splitOn)
 import Data.String (String)
 import qualified Data.Text as Text
 import Data.Version (showVersion)
@@ -231,13 +232,17 @@ pSlotNo =
 
 pKeepTxMetadata :: Parser [Word64]
 pKeepTxMetadata =
-  Opt.many
-    ( Opt.option
-        Opt.auto
-        ( Opt.long "keep-tx-metadata"
-            <> Opt.help "Insert a specific set of tx metadata, based on the tx metadata key names"
-        )
+  Opt.option
+    (parseCommaSeparated <$> Opt.str)
+    ( Opt.long "keep-tx-metadata"
+        <> Opt.help "Insert a specific set of tx metadata, based on the tx metadata key names"
     )
+  where
+    parseCommaSeparated :: String -> [Word64]
+    parseCommaSeparated str =
+      case traverse readMaybe (splitOn "," str) of
+        Just values -> values
+        Nothing -> error "Failed to parse comma-separated values"
 
 pHasInOut :: Parser Bool
 pHasInOut =

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -87,6 +87,7 @@ pRunDbSyncNode =
     <*> pHasShelley
     <*> pHasMultiAssets
     <*> pHasMetadata
+    <*> pKeepTxMetadata
     <*> pHasPlutusExtra
     <*> pHasGov
     <*> pHasOffChainPoolData
@@ -227,6 +228,15 @@ pSlotNo =
           <> Opt.help "Force a rollback to the specified slot (mainly for testing and debugging)."
           <> Opt.metavar "WORD"
       )
+
+pKeepTxMetadata :: Parser [Text]
+pKeepTxMetadata =
+  Opt.many
+    ( Opt.strOption
+        ( Opt.long "keep-tx-metadata"
+            <> Opt.help "Insert a specific set of tx metadata, based on the tx metadata key names"
+        )
+    )
 
 pHasInOut :: Parser Bool
 pHasInOut =

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -254,6 +254,7 @@ executable cardano-db-sync
                       , cardano-prelude
                       , cardano-slotting
                       , optparse-applicative
+                      , split
                       , text
 
 executable http-get-json-metadata

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -235,7 +235,7 @@ extractSyncOptions snp aop =
     iopts
       | enpOnlyGov snp = onlyGovInsertOptions useLedger
       | enpOnlyUTxO snp = onlyUTxOInsertOptions
-      | enpFullMode snp = fullInsertOptions useLedger
+      | enpFullMode snp = fullInsertOptions useLedger (enpKeepMetadataNames snp)
       | enpDisableAllMode snp = disableAllInsertOptions useLedger
       | otherwise =
           InsertOptions
@@ -245,6 +245,7 @@ extractSyncOptions snp aop =
             , ioRewards = True
             , ioMultiAssets = enpHasMultiAssets snp
             , ioMetadata = enpHasMetadata snp
+            , ioKeepMetadataNames = enpKeepMetadataNames snp
             , ioPlutusExtra = enpHasPlutusExtra snp
             , ioOffChainPoolData = enpHasOffChainPoolData snp
             , ioGov = enpHasGov snp

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -56,6 +56,7 @@ import Cardano.Prelude hiding (Nat, (%))
 import Cardano.Slotting.Slot (EpochNo (..))
 import Control.Concurrent.Async
 import Control.Monad.Extra (whenJust)
+import qualified Data.Strict.Maybe as Strict
 import qualified Data.Text as Text
 import Data.Version (showVersion)
 import Database.Persist.Postgresql (ConnectionString, withPostgresqlConn)
@@ -232,10 +233,15 @@ extractSyncOptions snp aop =
     , snapshotEveryLagging = enpSnEveryLagging snp
     }
   where
+    maybeKeepMNames =
+      if null (enpKeepMetadataNames snp)
+        then Strict.Just (enpKeepMetadataNames snp)
+        else Strict.Nothing
+
     iopts
       | enpOnlyGov snp = onlyGovInsertOptions useLedger
       | enpOnlyUTxO snp = onlyUTxOInsertOptions
-      | enpFullMode snp = fullInsertOptions useLedger (enpKeepMetadataNames snp)
+      | enpFullMode snp = fullInsertOptions useLedger maybeKeepMNames
       | enpDisableAllMode snp = disableAllInsertOptions useLedger
       | otherwise =
           InsertOptions
@@ -245,7 +251,7 @@ extractSyncOptions snp aop =
             , ioRewards = True
             , ioMultiAssets = enpHasMultiAssets snp
             , ioMetadata = enpHasMetadata snp
-            , ioKeepMetadataNames = enpKeepMetadataNames snp
+            , ioKeepMetadataNames = maybeKeepMNames
             , ioPlutusExtra = enpHasPlutusExtra snp
             , ioOffChainPoolData = enpHasOffChainPoolData snp
             , ioGov = enpHasGov snp

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -235,13 +235,13 @@ extractSyncOptions snp aop =
   where
     maybeKeepMNames =
       if null (enpKeepMetadataNames snp)
-        then Strict.Just (enpKeepMetadataNames snp)
-        else Strict.Nothing
+        then Strict.Nothing
+        else Strict.Just (enpKeepMetadataNames snp)
 
     iopts
       | enpOnlyGov snp = onlyGovInsertOptions useLedger
       | enpOnlyUTxO snp = onlyUTxOInsertOptions
-      | enpFullMode snp = fullInsertOptions useLedger maybeKeepMNames
+      | enpFullMode snp = fullInsertOptions useLedger
       | enpDisableAllMode snp = disableAllInsertOptions useLedger
       | otherwise =
           InsertOptions

--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -199,8 +199,20 @@ getPrunes :: SyncEnv -> Bool
 getPrunes = do
   DB.pcmPruneTxOut . getPruneConsume
 
-fullInsertOptions :: Bool -> Strict.Maybe [Word64] -> InsertOptions
-fullInsertOptions useLedger maybeKeepMNames = InsertOptions True useLedger True True True True maybeKeepMNames True True True
+fullInsertOptions :: Bool -> InsertOptions
+fullInsertOptions useLedger =
+  InsertOptions
+    { ioInOut = True
+    , ioUseLedger = useLedger
+    , ioShelley = True
+    , ioRewards = True
+    , ioMultiAssets = True
+    , ioMetadata = True
+    , ioKeepMetadataNames = Strict.Nothing
+    , ioPlutusExtra = True
+    , ioOffChainPoolData = True
+    , ioGov = True
+    }
 
 onlyUTxOInsertOptions :: InsertOptions
 onlyUTxOInsertOptions =
@@ -221,7 +233,19 @@ onlyGovInsertOptions :: Bool -> InsertOptions
 onlyGovInsertOptions useLedger = (disableAllInsertOptions useLedger) {ioGov = True}
 
 disableAllInsertOptions :: Bool -> InsertOptions
-disableAllInsertOptions useLedger = InsertOptions False useLedger False False False False Strict.Nothing False False False
+disableAllInsertOptions useLedger =
+  InsertOptions
+    { ioInOut = False
+    , ioUseLedger = useLedger
+    , ioShelley = False
+    , ioRewards = False
+    , ioMultiAssets = False
+    , ioMetadata = False
+    , ioKeepMetadataNames = Strict.Nothing
+    , ioPlutusExtra = False
+    , ioOffChainPoolData = False
+    , ioGov = False
+    }
 
 initEpochState :: EpochState
 initEpochState =

--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -199,8 +199,8 @@ getPrunes :: SyncEnv -> Bool
 getPrunes = do
   DB.pcmPruneTxOut . getPruneConsume
 
-fullInsertOptions :: Bool -> [Text] -> InsertOptions
-fullInsertOptions useLedger keepTxMDNames = InsertOptions True useLedger True True True True keepTxMDNames True True True
+fullInsertOptions :: Bool -> Strict.Maybe [Word64] -> InsertOptions
+fullInsertOptions useLedger maybeKeepMNames = InsertOptions True useLedger True True True True maybeKeepMNames True True True
 
 onlyUTxOInsertOptions :: InsertOptions
 onlyUTxOInsertOptions =
@@ -211,7 +211,7 @@ onlyUTxOInsertOptions =
     , ioRewards = False
     , ioMultiAssets = True
     , ioMetadata = False
-    , ioKeepMetadataNames = []
+    , ioKeepMetadataNames = Strict.Nothing
     , ioPlutusExtra = False
     , ioOffChainPoolData = False
     , ioGov = False
@@ -221,7 +221,7 @@ onlyGovInsertOptions :: Bool -> InsertOptions
 onlyGovInsertOptions useLedger = (disableAllInsertOptions useLedger) {ioGov = True}
 
 disableAllInsertOptions :: Bool -> InsertOptions
-disableAllInsertOptions useLedger = InsertOptions False useLedger False False False False [] False False False
+disableAllInsertOptions useLedger = InsertOptions False useLedger False False False False Strict.Nothing False False False
 
 initEpochState :: EpochState
 initEpochState =

--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -199,8 +199,8 @@ getPrunes :: SyncEnv -> Bool
 getPrunes = do
   DB.pcmPruneTxOut . getPruneConsume
 
-fullInsertOptions :: Bool -> InsertOptions
-fullInsertOptions useLedger = InsertOptions True useLedger True True True True True True True
+fullInsertOptions :: Bool -> [Text] -> InsertOptions
+fullInsertOptions useLedger keepTxMDNames = InsertOptions True useLedger True True True True keepTxMDNames True True True
 
 onlyUTxOInsertOptions :: InsertOptions
 onlyUTxOInsertOptions =
@@ -211,6 +211,7 @@ onlyUTxOInsertOptions =
     , ioRewards = False
     , ioMultiAssets = True
     , ioMetadata = False
+    , ioKeepMetadataNames = []
     , ioPlutusExtra = False
     , ioOffChainPoolData = False
     , ioGov = False
@@ -220,7 +221,7 @@ onlyGovInsertOptions :: Bool -> InsertOptions
 onlyGovInsertOptions useLedger = (disableAllInsertOptions useLedger) {ioGov = True}
 
 disableAllInsertOptions :: Bool -> InsertOptions
-disableAllInsertOptions useLedger = InsertOptions False useLedger False False False False False False False
+disableAllInsertOptions useLedger = InsertOptions False useLedger False False False False [] False False False
 
 initEpochState :: EpochState
 initEpochState =

--- a/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
@@ -23,7 +23,7 @@ import Cardano.DbSync.Types (
   OffChainVoteResult,
   OffChainVoteWorkQueue,
  )
-import Cardano.Prelude (Bool, Eq, IO, Show, Text, Word64)
+import Cardano.Prelude (Bool, Eq, IO, Show, Word64)
 import Cardano.Slotting.Slot (EpochNo (..))
 import Control.Concurrent.Class.MonadSTM.Strict (
   StrictTVar,
@@ -78,7 +78,7 @@ data InsertOptions = InsertOptions
   , ioRewards :: !Bool
   , ioMultiAssets :: !Bool
   , ioMetadata :: !Bool
-  , ioKeepMetadataNames :: ![Text]
+  , ioKeepMetadataNames :: Strict.Maybe [Word64]
   , ioPlutusExtra :: !Bool
   , ioOffChainPoolData :: !Bool
   , ioGov :: !Bool

--- a/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
@@ -23,7 +23,7 @@ import Cardano.DbSync.Types (
   OffChainVoteResult,
   OffChainVoteWorkQueue,
  )
-import Cardano.Prelude (Bool, Eq, IO, Show, Word64)
+import Cardano.Prelude (Bool, Eq, IO, Show, Text, Word64)
 import Cardano.Slotting.Slot (EpochNo (..))
 import Control.Concurrent.Class.MonadSTM.Strict (
   StrictTVar,
@@ -78,6 +78,7 @@ data InsertOptions = InsertOptions
   , ioRewards :: !Bool
   , ioMultiAssets :: !Bool
   , ioMetadata :: !Bool
+  , ioKeepMetadataNames :: ![Text]
   , ioPlutusExtra :: !Bool
   , ioOffChainPoolData :: !Bool
   , ioGov :: !Bool

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
@@ -72,6 +72,7 @@ data SyncNodeParams = SyncNodeParams
   , enpHasShelley :: !Bool
   , enpHasMultiAssets :: !Bool
   , enpHasMetadata :: !Bool
+  , enpKeepMetadataNames :: ![Text]
   , enpHasPlutusExtra :: !Bool
   , enpHasGov :: !Bool
   , enpHasOffChainPoolData :: !Bool

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
@@ -72,7 +72,7 @@ data SyncNodeParams = SyncNodeParams
   , enpHasShelley :: !Bool
   , enpHasMultiAssets :: !Bool
   , enpHasMetadata :: !Bool
-  , enpKeepMetadataNames :: ![Text]
+  , enpKeepMetadataNames :: ![Word64]
   , enpHasPlutusExtra :: !Bool
   , enpHasGov :: !Bool
   , enpHasOffChainPoolData :: !Bool

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -154,3 +154,9 @@ Some field are left empty when using this flag, like
 - `redeemer.script_hash` is left Null
 
 Until the ledger state migration happens any restart requires reusing the `--bootstrap-tx-out` flag. After it's completed the flag can be omitted on restarts.
+
+### --keep-tx-metadata
+
+This flag was introduced in v.13.2.0.0 as all postgres field with the type jsonb were removed to improve insertion performance.
+If they are required and you have database queries against jsonb then activate this flag to re-introduce the type jsonb.
+You can pass multiple values to the flag eg: `--keep-tx-metadata 1,2,3` make sure you are using commas between each key.


### PR DESCRIPTION
# Description

This fixes #1574 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
