### PR TITLE
Fix (ci): Update devx compiler names

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        compiler-nix-name: [ghc8107, ghc928, ghc962]
+        compiler-nix-name: [ghc810, ghc92, ghc96]
 
     steps:
       - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
       - name: cabal build
         run: cabal build all -j --enable-tests
       - name: postgres init
-        working-directory: 
+        working-directory:
         run: |
           # Set up environment
           PG_DIR="$(mktemp -d)"


### PR DESCRIPTION
# Description

Fixes #1591. The GitHub build uses old devx images, which is broken for MacOS. This is because devx now omits the minor version number:

 * ghc8107 -> ghc810
 * ghc928 -> ghc92
 * ghc963 -> ghc96

The reason the old images are broken for MacOS is the GHA-provided curl no longer works inside a nix-shell. The solution was to provide curl from nixpkgs.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
