### PR TITLE
Fix (CI): Reduce macOS GHA jobs

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,8 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         compiler-nix-name: [ghc810, ghc92, ghc96]
+        include:
+          # We want a single job, because macOS runners are scarce.
+          - os: macos-latest
+            compiler-nix-name: ghc810
 
     steps:
       - name: Checkout code

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        compiler-nix-name: [ghc810, ghc92, ghc96]
+        compiler-nix-name: [ghc810, ghc96]
         include:
           # We want a single job, because macOS runners are scarce.
           - os: macos-latest
-            compiler-nix-name: ghc810
+            compiler-nix-name: ghc96
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Description

macOS runners in GitHub are scarce (they are limited per-organizatiions), so we need to limit our jobs to one

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
