### PR TITLE
CI: Add aarch64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -186,11 +186,18 @@
             # for the target.
             shell.buildInputs = with nixpkgs.pkgsBuildBuild; [
               gitAndTools.git
-              fourmolu
               hlint
             ] ++ lib.optionals (config.compiler-nix-name == "ghc8107") [
               # Weeder requires the GHC version to match HIE files
               weeder
+            ] ++ lib.optionals (system != "aarch64-darwin") [
+              # TODO: Fourmolu 0.10 is currently failing to build with aarch64-darwin
+              #
+              # Linking dist/build/fourmolu/fourmolu ...
+              # ld: line 269:  2352 Segmentation fault ...
+              # clang-11: error: linker command failed with exit code 139 (use -v to see invocation)
+              # `cc' failed in phase `Linker'. (Exit code: 139)
+              fourmolu
             ];
             shell.withHoogle = true;
             shell.crossPlatforms = _: [];

--- a/flake.nix
+++ b/flake.nix
@@ -193,6 +193,7 @@
               weeder
             ];
             shell.withHoogle = true;
+            shell.crossPlatforms = _: [];
 
             modules = [
               ({ lib, pkgs, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -422,12 +422,13 @@
                 cardano-db-sync-linux
                 cardano-db-sync-docker
                 cardano-smash-server-docker;
+
+              # No need to run static checks on all architectures
+              checks = staticChecks;
             } // lib.optionalAttrs (system == "x86_64-darwin") {
               inherit cardano-db-sync-macos;
             } // {
               inherit cardano-smash-server-no-basic-auth profiled;
-
-              checks = staticChecks;
             };
 
             legacyPackages = pkgs;


### PR DESCRIPTION
# Description

Add aarch64-linux support for nix builds

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
