### PR TITLE
fix(cardano-db-sync): Default --keep-tx-metadata to []

### DIFF
--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -235,6 +235,7 @@ pKeepTxMetadata =
   Opt.option
     (parseCommaSeparated <$> Opt.str)
     ( Opt.long "keep-tx-metadata"
+        <> Opt.value []
         <> Opt.help "Insert a specific set of tx metadata, based on the tx metadata key names"
     )
   where


### PR DESCRIPTION
# Description

Should fix:

```
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]: Missing: --keep-tx-metadata ARG
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]: Usage: cardano-db-sync (COMMAND | --config FILEPATH --socket-path FILEPATH
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--state-dir FILEPATH] --schema-dir FILEPATH
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--pg-pass-env ENV] [--disable-epoch] [--disable-cache]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--disable-ledger] [--dont-use-ledger] [--skip-fix]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--fix-only] [--force-indexes] [--disable-in-out]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--disable-shelley] [--disable-multiassets]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--disable-metadata] --keep-tx-metadata ARG
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--disable-plutus-extra] [--disable-gov]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--disable-offchain-pool-data] [--force-tx-in]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--disable-all] [--full] [--only-utxo] [--only-gov]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--consumed-tx-out] [--prune-tx-out]
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:                          [--bootstrap-tx-out] [--rollback-to-slot WORD])
Jan 22 14:06:16 sean-work nv166z09gcc8fxkmyvv88rzq96h964nq-cardano-db-sync[900363]:   Cardano PostgreSQL sync node.
Jan 22 14:06:16 sean-work systemd[1]: cardano-db-sync.service: Main process exited, code=exited, status=1/FAILURE
```

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
