### PR TITLE
Test to allow custom Config values

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
@@ -229,8 +229,8 @@ mkConfig staticDir mutableDir cmdLineArgs config = do
   pure $ Config (Consensus.pInfoConfig pInfoDbSync) pInfoDbSync pInfoForger forging' syncPars
 
 mkSyncNodeConfig :: FilePath -> IO SyncNodeConfig
-mkSyncNodeConfig staticDir =
-  readSyncNodeConfig $ ConfigFile (staticDir </> "test-db-sync-config.json")
+mkSyncNodeConfig configFilePath =
+  readSyncNodeConfig $ ConfigFile (mkConfigDir configFilePath </> "test-db-sync-config.json")
 
 mkShelleyCredentials :: FilePath -> IO [ShelleyLeaderCredentials StandardCrypto]
 mkShelleyCredentials bulkFile = do
@@ -325,7 +325,16 @@ withFullConfig ::
   IOManager ->
   [(Text, Text)] ->
   IO a
-withFullConfig = withFullConfig' (WithConfigArgs True False False) initCommandLineArgs
+withFullConfig =
+  withFullConfig'
+    ( WithConfigArgs
+        { hasFingerprint = True
+        , shouldLog = False
+        , shouldDropDB = False
+        }
+    )
+    initCommandLineArgs
+    Nothing
 
 -- this function needs to be used where the schema needs to be rebuilt
 withFullConfigAndDropDB ::
@@ -337,19 +346,41 @@ withFullConfigAndDropDB ::
   IOManager ->
   [(Text, Text)] ->
   IO a
-withFullConfigAndDropDB = withFullConfig' (WithConfigArgs True False True) initCommandLineArgs
+withFullConfigAndDropDB =
+  withFullConfig'
+    ( WithConfigArgs
+        { hasFingerprint = True
+        , shouldLog = False
+        , shouldDropDB = True
+        }
+    )
+    initCommandLineArgs
+    Nothing
 
 withFullConfigAndLogs ::
+  -- | config filepath
   FilePath ->
+  -- | test label
   FilePath ->
   (Interpreter -> ServerHandle IO CardanoBlock -> DBSyncEnv -> IO a) ->
   IOManager ->
   [(Text, Text)] ->
   IO a
-withFullConfigAndLogs = withFullConfig' (WithConfigArgs True True False) initCommandLineArgs
+withFullConfigAndLogs =
+  withFullConfig'
+    ( WithConfigArgs
+        { hasFingerprint = True
+        , shouldLog = True
+        , shouldDropDB = False
+        }
+    )
+    initCommandLineArgs
+    Nothing
 
 withCustomConfig ::
   CommandLineArgs ->
+  -- | custom SyncNodeConfig
+  Maybe SyncNodeConfig ->
   -- | config filepath
   FilePath ->
   -- | test label
@@ -358,10 +389,19 @@ withCustomConfig ::
   IOManager ->
   [(Text, Text)] ->
   IO a
-withCustomConfig = withFullConfig' (WithConfigArgs True False False)
+withCustomConfig =
+  withFullConfig'
+    ( WithConfigArgs
+        { hasFingerprint = True
+        , shouldLog = False
+        , shouldDropDB = False
+        }
+    )
 
 withCustomConfigAndDropDB ::
   CommandLineArgs ->
+  -- | custom SyncNodeConfig
+  Maybe SyncNodeConfig ->
   -- | config filepath
   FilePath ->
   -- | test label
@@ -370,11 +410,20 @@ withCustomConfigAndDropDB ::
   IOManager ->
   [(Text, Text)] ->
   IO a
-withCustomConfigAndDropDB = withFullConfig' (WithConfigArgs True False True)
+withCustomConfigAndDropDB =
+  withFullConfig'
+    ( WithConfigArgs
+        { hasFingerprint = True
+        , shouldLog = False
+        , shouldDropDB = True
+        }
+    )
 
 -- This is a usefull function to be able to see logs from DBSync when writing/debuging tests
 withCustomConfigAndLogs ::
   CommandLineArgs ->
+  -- | custom SyncNodeConfig
+  Maybe SyncNodeConfig ->
   -- | config filepath
   FilePath ->
   -- | test label
@@ -383,11 +432,20 @@ withCustomConfigAndLogs ::
   IOManager ->
   [(Text, Text)] ->
   IO a
-withCustomConfigAndLogs = withFullConfig' (WithConfigArgs True True False)
+withCustomConfigAndLogs =
+  withFullConfig'
+    ( WithConfigArgs
+        { hasFingerprint = True
+        , shouldLog = True
+        , shouldDropDB = False
+        }
+    )
 
 withFullConfig' ::
   WithConfigArgs ->
   CommandLineArgs ->
+  -- | custom SyncNodeConfig
+  Maybe SyncNodeConfig ->
   -- | config filepath
   FilePath ->
   -- | test label
@@ -396,9 +454,15 @@ withFullConfig' ::
   IOManager ->
   [(Text, Text)] ->
   IO a
-withFullConfig' WithConfigArgs {..} cmdLineArgs configFilePath testLabelFilePath action iom migr = do
+withFullConfig' WithConfigArgs {..} cmdLineArgs mSyncNodeConfig configFilePath testLabelFilePath action iom migr = do
   recreateDir mutableDir
-  cfg <- mkConfig configDir mutableDir cmdLineArgs =<< mkSyncNodeConfig configDir
+  -- check if custom syncNodeConfigs have been passed or not
+  syncNodeConfig <-
+    case mSyncNodeConfig of
+      Just snc -> pure snc
+      Nothing -> mkSyncNodeConfig configFilePath
+
+  cfg <- mkConfig (mkConfigDir configFilePath) mutableDir cmdLineArgs syncNodeConfig
   fingerFile <- if hasFingerprint then Just <$> prepareFingerprintFile testLabelFilePath else pure Nothing
   let dbsyncParams = syncNodeParams cfg
   trce <-
@@ -406,7 +470,7 @@ withFullConfig' WithConfigArgs {..} cmdLineArgs configFilePath testLabelFilePath
       then configureLogging dbsyncParams "db-sync-node"
       else pure nullTracer
   -- runDbSync is partially applied so we can pass in syncNodeParams at call site / within tests
-  let partialDbSyncRun params = runDbSync emptyMetricsSetters migr iom trce params True
+  let partialDbSyncRun params = runDbSync emptyMetricsSetters migr iom trce params syncNodeConfig True
       initSt = Consensus.pInfoInitLedger $ protocolInfo cfg
 
   withInterpreter (protocolInfoForging cfg) (protocolInfoForger cfg) nullTracer fingerFile $ \interpreter -> do
@@ -429,7 +493,6 @@ withFullConfig' WithConfigArgs {..} cmdLineArgs configFilePath testLabelFilePath
             else void . hSilence [stderr] $ Db.truncateTables pgPass tableNames
           action interpreter mockServer dbSyncEnv
   where
-    configDir = mkConfigDir configFilePath
     mutableDir = mkMutableDir testLabelFilePath
 
 prepareFingerprintFile :: FilePath -> IO FilePath

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
@@ -467,7 +467,7 @@ withFullConfig' WithConfigArgs {..} cmdLineArgs mSyncNodeConfig configFilePath t
   let dbsyncParams = syncNodeParams cfg
   trce <-
     if shouldLog
-      then configureLogging dbsyncParams "db-sync-node"
+      then configureLogging syncNodeConfig "db-sync-node"
       else pure nullTracer
   -- runDbSync is partially applied so we can pass in syncNodeParams at call site / within tests
   let partialDbSyncRun params = runDbSync emptyMetricsSetters migr iom trce params syncNodeConfig True

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Property/Property.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Property/Property.hs
@@ -274,4 +274,4 @@ prop_empty_blocks iom knownMigrations = withMaxSuccess 20 $ noShrinking $ forAll
   prettyCommands smSymbolic hist (checkCommandNames cmds (res === Ok))
   where
     smSymbolic = sm (error "inter") (error "mockServer") (error "dbSync")
-    runAction action = withFullConfig' (WithConfigArgs False False False) initCommandLineArgs "config" "qsm" action iom knownMigrations
+    runAction action = withFullConfig' (WithConfigArgs False False False) initCommandLineArgs Nothing "config" "qsm" action iom knownMigrations

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/ConfigFile.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/ConfigFile.hs
@@ -12,7 +12,7 @@ import Test.Tasty.HUnit (Assertion)
 -- this test fails as incorrect configuration file given
 checkConfigFileArg :: IOManager -> [(Text, Text)] -> Assertion
 checkConfigFileArg =
-  withCustomConfig commandLineConfigArgs babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
+  withCustomConfig commandLineConfigArgs Nothing babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
     -- poll dbSync to see if it's running, which it shouldn't
     checkStillRuns dbSyncEnv
   where

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/EpochDisabled.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/EpochDisabled.hs
@@ -21,7 +21,7 @@ mkCommandLineArgs epochDisabled = initCommandLineArgs {claEpochDisabled = epochD
 -- this test fails as incorrect configuration file given
 checkEpochDisabledArg :: IOManager -> [(Text, Text)] -> Assertion
 checkEpochDisabledArg =
-  withCustomConfigAndDropDB (mkCommandLineArgs True) babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfigAndDropDB (mkCommandLineArgs True) Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     b1 <- forgeAndSubmitBlocks interpreter mockServer 50
     -- add 2 blocks with tx
@@ -36,7 +36,7 @@ checkEpochDisabledArg =
 
 checkEpochEnabled :: IOManager -> [(Text, Text)] -> Assertion
 checkEpochEnabled =
-  withCustomConfig (mkCommandLineArgs False) babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig (mkCommandLineArgs False) Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     b1 <- forgeAndSubmitBlocks interpreter mockServer 50
     -- add 2 blocks with tx

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/ForceIndex.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/ForceIndex.hs
@@ -16,7 +16,7 @@ import Test.Tasty.HUnit (Assertion)
 
 checkForceIndexesArg :: IOManager -> [(Text, Text)] -> Assertion
 checkForceIndexesArg =
-  withCustomConfig commandLineForceIndexArgs babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
+  withCustomConfig commandLineForceIndexArgs Nothing babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
     startDBSync dbSyncEnv
     threadDelay 3_000_000
     assertEqQuery dbSyncEnv DB.queryPgIndexesCount 162 "there wasn't the correct number of indexes"
@@ -29,7 +29,7 @@ checkForceIndexesArg =
 
 checkNoForceIndexesArg :: IOManager -> [(Text, Text)] -> Assertion
 checkNoForceIndexesArg =
-  withCustomConfigAndDropDB commandLineNoForceIndexArgs babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
+  withCustomConfigAndDropDB commandLineNoForceIndexArgs Nothing babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
     startDBSync dbSyncEnv
     threadDelay 3_000_000
     assertEqQuery dbSyncEnv DB.queryPgIndexesCount 97 "there wasn't the correct number of indexes"

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/MigrateConsumedPruneTxOut.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/MigrateConsumedPruneTxOut.hs
@@ -51,7 +51,7 @@ import Test.Tasty.HUnit (Assertion)
 
 commandLineArgCheck :: IOManager -> [(Text, Text)] -> Assertion
 commandLineArgCheck = do
-  withCustomConfigAndDropDB cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfigAndDropDB cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     void $
       withBabbageFindLeaderAndSubmitTx interpreter mockServer $
         Babbage.mkPaymentTx (UTxOIndex 0) (UTxOIndex 1) 10000 500
@@ -69,7 +69,7 @@ commandLineArgCheck = do
 
 basicPrune :: IOManager -> [(Text, Text)] -> Assertion
 basicPrune = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     -- add 50 block
     b1 <- forgeAndSubmitBlocks interpreter mockServer 50
@@ -98,7 +98,7 @@ basicPrune = do
 
 pruneWithSimpleRollback :: IOManager -> [(Text, Text)] -> Assertion
 pruneWithSimpleRollback = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     blk0 <- forgeNext interpreter mockBlock0
     blk1 <- forgeNext interpreter mockBlock1
     atomically $ addBlock mockServer blk0
@@ -128,7 +128,7 @@ pruneWithSimpleRollback = do
 
 pruneWithFullTxRollback :: IOManager -> [(Text, Text)] -> Assertion
 pruneWithFullTxRollback = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     blk0 <- forgeNextFindLeaderAndSubmit interpreter mockServer []
     void $ withBabbageFindLeaderAndSubmit interpreter mockServer $ \st -> do
@@ -162,7 +162,7 @@ pruneWithFullTxRollback = do
 -- In these tests, 2 x securityParam = 20 blocks.
 pruningShouldKeepSomeTx :: IOManager -> [(Text, Text)] -> Assertion
 pruningShouldKeepSomeTx = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     b1 <- forgeAndSubmitBlocks interpreter mockServer 80
     -- these two blocs + tx will fall withing the last 20 blocks so should not be pruned
@@ -189,7 +189,7 @@ pruningShouldKeepSomeTx = do
 -- prune with rollback
 pruneAndRollBackOneBlock :: IOManager -> [(Text, Text)] -> Assertion
 pruneAndRollBackOneBlock = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     void $ forgeAndSubmitBlocks interpreter mockServer 98
     -- add 2 blocks with tx
@@ -225,7 +225,7 @@ pruneAndRollBackOneBlock = do
 -- consume with rollback
 noPruneAndRollBack :: IOManager -> [(Text, Text)] -> Assertion
 noPruneAndRollBack = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     void $ forgeAndSubmitBlocks interpreter mockServer 98
     -- add 2 blocks with tx
@@ -260,7 +260,7 @@ noPruneAndRollBack = do
 
 pruneSameBlock :: IOManager -> [(Text, Text)] -> Assertion
 pruneSameBlock =
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     void $ forgeAndSubmitBlocks interpreter mockServer 76
     blk77 <- forgeNextFindLeaderAndSubmit interpreter mockServer []
@@ -289,7 +289,7 @@ pruneSameBlock =
 
 noPruneSameBlock :: IOManager -> [(Text, Text)] -> Assertion
 noPruneSameBlock =
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     void $ forgeAndSubmitBlocks interpreter mockServer 96
     blk97 <- forgeNextFindLeaderAndSubmit interpreter mockServer []
@@ -315,7 +315,7 @@ noPruneSameBlock =
 
 migrateAndPruneRestart :: IOManager -> [(Text, Text)] -> Assertion
 migrateAndPruneRestart = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     let DBSyncEnv {..} = dbSyncEnv
     startDBSync dbSyncEnv
     void $ forgeAndSubmitBlocks interpreter mockServer 50
@@ -340,7 +340,7 @@ migrateAndPruneRestart = do
 
 pruneRestartMissingFlag :: IOManager -> [(Text, Text)] -> Assertion
 pruneRestartMissingFlag = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     let DBSyncEnv {..} = dbSyncEnv
 
     startDBSync dbSyncEnv
@@ -366,7 +366,7 @@ pruneRestartMissingFlag = do
 
 bootstrapRestartMissingFlag :: IOManager -> [(Text, Text)] -> Assertion
 bootstrapRestartMissingFlag = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfig cmdLineArgs Nothing babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     let DBSyncEnv {..} = dbSyncEnv
     startDBSync dbSyncEnv
     void $ forgeAndSubmitBlocks interpreter mockServer 50

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/CommandLineArg/ConfigFile.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/CommandLineArg/ConfigFile.hs
@@ -13,7 +13,7 @@ import Prelude ()
 
 checkConfigFileArg :: IOManager -> [(Text, Text)] -> Assertion
 checkConfigFileArg =
-  withCustomConfig cliArgs conwayConfigDir testLabel $ \_ _ dbSync -> do
+  withCustomConfig cliArgs Nothing conwayConfigDir testLabel $ \_ _ dbSync -> do
     startDBSync dbSync
     -- There is a slight delay before the flag is checked
     threadDelay 2_000_000

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/CommandLineArg/EpochDisabled.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/CommandLineArg/EpochDisabled.hs
@@ -18,7 +18,7 @@ import Prelude ()
 
 checkEpochDisabledArg :: IOManager -> [(Text, Text)] -> Assertion
 checkEpochDisabledArg =
-  withCustomConfigAndDropDB cliArgs conwayConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withCustomConfigAndDropDB cliArgs Nothing conwayConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     -- Forge some blocks
@@ -42,7 +42,7 @@ checkEpochDisabledArg =
 
 checkEpochEnabled :: IOManager -> [(Text, Text)] -> Assertion
 checkEpochEnabled =
-  withCustomConfig cliArgs conwayConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withCustomConfig cliArgs Nothing conwayConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     -- Forge some blocks

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/CommandLineArg/ForceIndex.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/CommandLineArg/ForceIndex.hs
@@ -13,7 +13,7 @@ import Prelude ()
 
 checkForceIndexesArg :: IOManager -> [(Text, Text)] -> Assertion
 checkForceIndexesArg =
-  withCustomConfig cliArgs conwayConfigDir testLabel $ \_ _ dbSync -> do
+  withCustomConfig cliArgs Nothing conwayConfigDir testLabel $ \_ _ dbSync -> do
     startDBSync dbSync
 
     -- Verify number of DB indexes
@@ -24,7 +24,7 @@ checkForceIndexesArg =
 
 checkNoForceIndexesArg :: IOManager -> [(Text, Text)] -> Assertion
 checkNoForceIndexesArg =
-  withCustomConfigAndDropDB cliArgs conwayConfigDir testLabel $ \_ _ dbSync -> do
+  withCustomConfigAndDropDB cliArgs Nothing conwayConfigDir testLabel $ \_ _ dbSync -> do
     startDBSync dbSync
 
     -- Verify number of DB indexes

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Config.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Config.hs
@@ -20,18 +20,18 @@ import Prelude ()
 conwayGenesis :: Assertion
 conwayGenesis =
   mkSyncNodeConfig configDir
-    >>= void . mkConfig configDir mutableDir cmdLineArgs
+    >>= void . mkConfig (mkConfigDir configDir) mutableDir cmdLineArgs
   where
-    configDir = mkConfigDir "config-conway"
+    configDir = "config-conway"
     mutableDir = mkMutableDir "conwayConfigSimple"
     cmdLineArgs = initCommandLineArgs
 
 missingConwayGenesis :: Assertion
 missingConwayGenesis = do
-  res <- try $ mkConfig configDir mutableDir cmdLineArgs =<< mkSyncNodeConfig configDir
+  res <- try $ mkConfig (mkConfigDir configDir) mutableDir cmdLineArgs =<< mkSyncNodeConfig configDir
   assertBool "Not a SyncNodeError" (isConwayConfigError res)
   where
-    configDir = mkConfigDir "config-conway-missing-genesis"
+    configDir = "config-conway-missing-genesis"
     mutableDir = mkMutableDir "conwayConfigMissingGenesis"
     cmdLineArgs = initCommandLineArgs
 
@@ -40,9 +40,9 @@ noConwayGenesis = do
   cfg <- mkSyncNodeConfig configDir
   let cfg' = cfg {dncConwayGenesisFile = Nothing}
   void $
-    mkConfig configDir mutableDir cmdLineArgs cfg'
+    mkConfig (mkConfigDir configDir) mutableDir cmdLineArgs cfg'
   where
-    configDir = mkConfigDir "config-conway"
+    configDir = "config-conway"
     mutableDir = mkMutableDir "conwayConfigNoGenesis"
     cmdLineArgs = initCommandLineArgs
 
@@ -51,9 +51,9 @@ noConwayGenesisHash = do
   cfg <- mkSyncNodeConfig configDir
   let cfg' = cfg {dncConwayGenesisHash = Nothing}
   void $
-    mkConfig configDir mutableDir initCommandLineArgs cfg'
+    mkConfig (mkConfigDir configDir) mutableDir initCommandLineArgs cfg'
   where
-    configDir = mkConfigDir "config-conway"
+    configDir = "config-conway"
     mutableDir = mkMutableDir "conwayConfigNoGenesis"
 
 wrongConwayGenesisHash :: Assertion
@@ -62,10 +62,10 @@ wrongConwayGenesisHash = do
   hash <- Aeson.throwDecode "\"0000000000000000000000000000000000000000000000000000000000000000\""
   let cfg' = cfg {dncConwayGenesisHash = Just hash}
 
-  res <- try (mkConfig configDir mutableDir initCommandLineArgs cfg')
+  res <- try (mkConfig (mkConfigDir configDir) mutableDir initCommandLineArgs cfg')
   assertBool "Not a SyncNodeError" (isConwayConfigError res)
   where
-    configDir = mkConfigDir "config-conway"
+    configDir = "config-conway"
     mutableDir = mkMutableDir "configConwayWrongGenesis"
 
 isConwayConfigError :: Either SyncNodeError a -> Bool

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -41,9 +41,11 @@ main = do
 
     run :: SyncNodeParams -> IO ()
     run prms = do
-      prometheusPort <- dncPrometheusPort <$> readSyncNodeConfig (enpConfigFile prms)
+      -- read the config file as early as possible
+      syncNodeConfigFromFile <- readSyncNodeConfig (enpConfigFile prms)
+      let prometheusPort = dncPrometheusPort syncNodeConfigFromFile
       withMetricSetters prometheusPort $ \metricsSetters ->
-        runDbSyncNode metricsSetters knownMigrationsPlain prms
+        runDbSyncNode metricsSetters knownMigrationsPlain prms syncNodeConfigFromFile
 
 -- -------------------------------------------------------------------------------------------------
 
@@ -70,7 +72,7 @@ depricated =
       <> Opt.hidden
 
 pRunDbSyncNode :: Parser SyncNodeParams
-pRunDbSyncNode =
+pRunDbSyncNode = do
   SyncNodeParams
     <$> pConfigFile
     <*> pSocketPath

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -29,7 +29,7 @@ import Cardano.Db (textShow)
 import qualified Cardano.Db as Db
 import Cardano.DbSync.Api
 import Cardano.DbSync.Api.Types (InsertOptions (..), RunMigration, SyncEnv (..), SyncOptions (..), envLedgerEnv)
-import Cardano.DbSync.Config (configureLogging, readSyncNodeConfig)
+import Cardano.DbSync.Config (configureLogging)
 import Cardano.DbSync.Config.Cardano
 import Cardano.DbSync.Config.Types (
   ConfigFile (..),
@@ -65,15 +65,15 @@ import Paths_cardano_db_sync (version)
 import System.Directory (createDirectoryIfMissing)
 import Prelude (id)
 
-runDbSyncNode :: MetricSetters -> [(Text, Text)] -> SyncNodeParams -> IO ()
-runDbSyncNode metricsSetters knownMigrations params =
+runDbSyncNode :: MetricSetters -> [(Text, Text)] -> SyncNodeParams -> SyncNodeConfig -> IO ()
+runDbSyncNode metricsSetters knownMigrations params syncNodeConfigFromFile =
   withIOManager $ \iomgr -> do
     trce <- configureLogging params "db-sync-node"
 
-    aop <- hasAbortOnPanicEnv
-    startupReport trce aop params
+    abortOnPanic <- hasAbortOnPanicEnv
+    startupReport trce abortOnPanic params
 
-    runDbSync metricsSetters knownMigrations iomgr trce params aop
+    runDbSync metricsSetters knownMigrations iomgr trce params syncNodeConfigFromFile abortOnPanic
 
 runDbSync ::
   MetricSetters ->
@@ -81,9 +81,11 @@ runDbSync ::
   IOManager ->
   Trace IO Text ->
   SyncNodeParams ->
+  SyncNodeConfig ->
+  -- Should abort on panic
   Bool ->
   IO ()
-runDbSync metricsSetters knownMigrations iomgr trce params aop = do
+runDbSync metricsSetters knownMigrations iomgr trce params syncNodeConfigFromFile abortOnPanic = do
   logInfo trce $ textShow syncOpts
   -- Read the PG connection info
   pgConfig <- runOrThrowIO (Db.readPGPass $ enpPGPassSource params)
@@ -124,7 +126,7 @@ runDbSync metricsSetters knownMigrations iomgr trce params aop = do
   -- For testing and debugging.
   whenJust (enpMaybeRollback params) $ \slotNo ->
     void $ unsafeRollback trce pgConfig slotNo
-  runSyncNode metricsSetters trce iomgr connectionString ranMigrations (void . runMigration) params syncOpts
+  runSyncNode metricsSetters trce iomgr connectionString ranMigrations (void . runMigration) syncNodeConfigFromFile params syncOpts
   where
     dbMigrationDir :: Db.MigrationDir
     dbMigrationDir = enpMigrationDir params
@@ -139,7 +141,7 @@ runDbSync metricsSetters knownMigrations iomgr trce params aop = do
         , " in the schema directory and restart it."
         ]
 
-    syncOpts = extractSyncOptions params aop
+    syncOpts = extractSyncOptions params abortOnPanic
 
 runSyncNode ::
   MetricSetters ->
@@ -150,23 +152,22 @@ runSyncNode ::
   Bool ->
   -- | run migration function
   RunMigration ->
+  SyncNodeConfig ->
   SyncNodeParams ->
   SyncOptions ->
   IO ()
-runSyncNode metricsSetters trce iomgr dbConnString ranMigrations runMigrationFnc syncNodeParams syncOptions = do
-  syncNodeConfig <- readSyncNodeConfig configFile
+runSyncNode metricsSetters trce iomgr dbConnString ranMigrations runMigrationFnc syncNodeConfigFromFile syncNodeParams syncOptions = do
   whenJust maybeLedgerDir $
     \enpLedgerStateDir -> do
       createDirectoryIfMissing True (unLedgerStateDir enpLedgerStateDir)
-
-  logInfo trce $ "Using byron genesis file from: " <> (show . unGenesisFile $ dncByronGenesisFile syncNodeConfig)
-  logInfo trce $ "Using shelley genesis file from: " <> (show . unGenesisFile $ dncShelleyGenesisFile syncNodeConfig)
-  logInfo trce $ "Using alonzo genesis file from: " <> (show . unGenesisFile $ dncAlonzoGenesisFile syncNodeConfig)
+  logInfo trce $ "Using byron genesis file from: " <> (show . unGenesisFile $ dncByronGenesisFile syncNodeConfigFromFile)
+  logInfo trce $ "Using shelley genesis file from: " <> (show . unGenesisFile $ dncShelleyGenesisFile syncNodeConfigFromFile)
+  logInfo trce $ "Using alonzo genesis file from: " <> (show . unGenesisFile $ dncAlonzoGenesisFile syncNodeConfigFromFile)
   Db.runIohkLogging trce $
     withPostgresqlConn dbConnString $
       \backend -> liftIO $ do
         runOrThrowIO $ runExceptT $ do
-          genCfg <- readCardanoGenesisConfig syncNodeConfig
+          genCfg <- readCardanoGenesisConfig syncNodeConfigFromFile
           logProtocolMagicId trce $ genesisProtocolMagicId genCfg
           syncEnv <-
             ExceptT $
@@ -176,6 +177,7 @@ runSyncNode metricsSetters trce iomgr dbConnString ranMigrations runMigrationFnc
                 dbConnString
                 syncOptions
                 genCfg
+                syncNodeConfigFromFile
                 syncNodeParams
                 ranMigrations
                 runMigrationFnc
@@ -183,7 +185,7 @@ runSyncNode metricsSetters trce iomgr dbConnString ranMigrations runMigrationFnc
           unless (enpShouldUseLedger syncNodeParams) $ liftIO $ do
             logInfo trce "Migrating to a no ledger schema"
             Db.noLedgerMigrations backend trce
-          insertValidateGenesisDist syncEnv (dncNetworkName syncNodeConfig) genCfg (useShelleyInit syncNodeConfig)
+          insertValidateGenesisDist syncEnv (dncNetworkName syncNodeConfigFromFile) genCfg (useShelleyInit syncNodeConfigFromFile)
 
           -- communication channel between datalayer thread and chainsync-client thread
           threadChannels <- liftIO newThreadChannels
@@ -203,7 +205,6 @@ runSyncNode metricsSetters trce iomgr dbConnString ranMigrations runMigrationFnc
         HardFork.TriggerHardForkAtEpoch (EpochNo 0) -> True
         _ -> False
 
-    configFile = enpConfigFile syncNodeParams
     maybeLedgerDir = enpMaybeLedgerStateDir syncNodeParams
 
 logProtocolMagicId :: Trace IO Text -> Crypto.ProtocolMagicId -> ExceptT SyncNodeError IO ()

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -68,7 +68,7 @@ import Prelude (id)
 runDbSyncNode :: MetricSetters -> [(Text, Text)] -> SyncNodeParams -> SyncNodeConfig -> IO ()
 runDbSyncNode metricsSetters knownMigrations params syncNodeConfigFromFile =
   withIOManager $ \iomgr -> do
-    trce <- configureLogging params "db-sync-node"
+    trce <- configureLogging syncNodeConfigFromFile "db-sync-node"
 
     abortOnPanic <- hasAbortOnPanicEnv
     startupReport trce abortOnPanic params

--- a/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
@@ -15,6 +15,7 @@ module Cardano.DbSync.Api.Types (
 
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Cache.Types (Cache)
+import Cardano.DbSync.Config.Types (SyncNodeConfig)
 import Cardano.DbSync.Ledger.Types (HasLedgerEnv)
 import Cardano.DbSync.LocalStateQuery (NoLedgerEnv)
 import Cardano.DbSync.Types (
@@ -54,6 +55,7 @@ data SyncEnv = SyncEnv
   , envOffChainVoteResultQueue :: !(StrictTBQueue IO OffChainVoteResult)
   , envOffChainVoteWorkQueue :: !(StrictTBQueue IO OffChainVoteWorkQueue)
   , envOptions :: !SyncOptions
+  , envSyncNodeConfig :: !SyncNodeConfig
   , envRunDelayedMigration :: RunMigration
   , envSystemStart :: !SystemStart
   }

--- a/cardano-db-sync/src/Cardano/DbSync/Config.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config.hs
@@ -33,14 +33,11 @@ import Cardano.DbSync.Config.Types
 import Cardano.Prelude
 import System.FilePath (takeDirectory, (</>))
 
-configureLogging :: SyncNodeParams -> Text -> IO (Trace IO Text)
-configureLogging params loggingName = do
-  let configFile = enpConfigFile params
-  enc <- readSyncNodeConfig configFile
-
-  if not (dncEnableLogging enc)
+configureLogging :: SyncNodeConfig -> Text -> IO (Trace IO Text)
+configureLogging syncNodeConfig loggingName = do
+  if not (dncEnableLogging syncNodeConfig)
     then pure Logging.nullTracer
-    else liftIO $ Logging.setupTrace (Right $ dncLoggingConfig enc) loggingName
+    else liftIO $ Logging.setupTrace (Right $ dncLoggingConfig syncNodeConfig) loggingName
 
 readSyncNodeConfig :: ConfigFile -> IO SyncNodeConfig
 readSyncNodeConfig (ConfigFile fp) = do


### PR DESCRIPTION
# Description

This fixes #1618 
Also multiple reading of the config file is mitigated to just once when db-sync starts.

We can now read a config json file once in the test class that as an init and update it with any custom values required for testing. A single example of it working is:

https://github.com/IntersectMBO/cardano-db-sync/blob/eecc3ee307d425ca29d507b81b4d692615bf85f2/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/CommandLineArg/MigrateConsumedPruneTxOut.hs#L38-L65

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
