### PR TITLE
Fix: Upgrade PostgreSQL@14.10 in docker-compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   postgres:
-    image: postgres:11.18-alpine
+    image: postgres:14.10-alpine
     environment:
       - POSTGRES_LOGGING=true
       - POSTGRES_DB_FILE=/run/secrets/postgres_db
@@ -32,7 +32,7 @@ services:
         max-file: "10"
 
   cardano-node:
-    image: inputoutput/cardano-node:8.0.0
+    image: ghcr.io/intersectmbo/cardano-node:8.7.3
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -53,7 +53,7 @@ services:
         max-file: "10"
 
   cardano-db-sync:
-    image: inputoutput/cardano-db-sync:13.2.0.0
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.2.0.0
     environment:
       - DISABLE_LEDGER=${DISABLE_LEDGER}
       - NETWORK=${NETWORK:-mainnet}

--- a/docker-test.yml
+++ b/docker-test.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   postgres:
-    image: postgres:11.5-alpine
+    image: postgres:14.10-alpine
     environment:
       - POSTGRES_LOGGING=true
       - POSTGRES_DB_FILE=/run/secrets/postgres_db
@@ -33,4 +33,3 @@ secrets:
 
 volumes:
   postgres:
-


### PR DESCRIPTION
# Description

Upgrade PostgreSQL and Cardano Node to sufficiently new versions in docker-compose projects. Fixes #1622 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
