### PR TITLE
1421 update logs for Unicode Nul character

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
@@ -88,7 +88,7 @@ insertRedeemerData tracer txId txd = do
   case mRedeemerDataId of
     Just redeemerDataId -> pure redeemerDataId
     Nothing -> do
-      value <- safeDecodeToJson tracer "insertRedeemerData" $ Generic.txDataValue txd
+      value <- safeDecodeToJson tracer "insertDatum: Column 'value' in table 'datum' " $ Generic.txDataValue txd
       lift
         . DB.insertRedeemerData
         $ DB.RedeemerData
@@ -113,7 +113,7 @@ insertDatum tracer cache txId txd = do
   case mDatumId of
     Just datumId -> pure datumId
     Nothing -> do
-      value <- safeDecodeToJson tracer "insertDatum" $ Generic.txDataValue txd
+      value <- safeDecodeToJson tracer "insertRedeemerData: Column 'value' in table 'redeemer' " $ Generic.txDataValue txd
       lift $
         insertDatumAndCache cache (Generic.txDataHash txd) $
           DB.Datum
@@ -203,7 +203,7 @@ insertScript tracer txId script = do
   where
     scriptConvert :: MonadIO m => Generic.TxScript -> m (Maybe Text)
     scriptConvert s =
-      maybe (pure Nothing) (safeDecodeToJson tracer "insertScript") (Generic.txScriptJson s)
+      maybe (pure Nothing) (safeDecodeToJson tracer "insertScript: Column 'json' in table 'script' ") (Generic.txScriptJson s)
 
 insertExtraKeyWitness ::
   (MonadBaseControl IO m, MonadIO m) =>

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Tx.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Tx.hs
@@ -260,7 +260,7 @@ insertTxMetadata tracer txId inOpts mmetadata = do
     mkDbTxMetadata (key, md) = do
       let jsonbs = LBS.toStrict $ Aeson.encode (metadataValueToJsonNoSchema md)
           singleKeyCBORMetadata = serialiseTxMetadataToCbor $ Map.singleton key md
-      mjson <- safeDecodeToJson tracer "insertTxMetadata" jsonbs
+      mjson <- safeDecodeToJson tracer "prepareTxMetadata: Column 'json' in table 'metadata' " jsonbs
       pure $
         Just $
           DB.TxMetadata

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Util.hs
@@ -47,6 +47,6 @@ safeDecodeToJson tracer tracePrefix x = do
       -- See https://github.com/IntersectMBO/cardano-db-sync/issues/297
       if containsUnicodeNul json
         then do
-          liftIO $ logWarning tracer $ tracePrefix <> ": dropped due to a Unicode NUL character. " <> json
+          liftIO $ logWarning tracer $ tracePrefix <> "was recorded as null, due to a Unicode NUL character found when trying to parse the json."
           pure Nothing
         else pure $ Just json


### PR DESCRIPTION
# Description

this fixes #1421 

The logs were false in that not the whole row was drop, but instead if parsing failed with a Unicode Nul character the specific column it was intended for is recorded as `nul`.

This also effected a couple of other places so those were updated too.

```
[db-sync-node:Warning:75] [2024-01-31 11:02:29.12 UTC]  prepareTxMetadata: Column 'json' in table 'metadata' was recorded as null, due to a Unicode NUL character found when trying to parse the json.
```

This also fixes #1623 as outputting the full json made logs quite perplexing.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
