### PR TITLE
Fix: Update "only_utxo" preset config

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -227,7 +227,7 @@ fullInsertOptions =
 onlyUTxOInsertOptions :: SyncInsertOptions
 onlyUTxOInsertOptions =
   SyncInsertOptions
-    { sioTxOut = TxOutEnable
+    { sioTxOut = TxOutBootstrap (ForceTxIn False)
     , sioLedger = LedgerIgnore
     , sioShelley = ShelleyDisable
     , sioRewards = RewardsConfig True

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -97,6 +97,12 @@ This is equivalent to setting:
 "shelley": {
   "enable": false
 },
+"metadata": {
+  "enable": "false"
+},
+"multi_asset": {
+  "enable": "false"
+},
 "plutus": {
   "enable": false
 },


### PR DESCRIPTION
# Description

Set tx_out = bootstrap to match docs. Fixes #1638 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
