### PR TITLE
Fix: Add `gnused` to docker image

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -7,8 +7,9 @@
 
 # Image dependencies
 , bashInteractive, cacert, cardano-cli, cardano-db-sync, cardano-db-tool
-, coreutils, curl, findutils, getconf, glibcLocales, gnutar, gzip, jq, iana-etc
-, iproute, iputils, lib, libidn, libpqxx, postgresql, socat, utillinux
+, coreutils, curl, findutils, getconf, glibcLocales, gnutar, gnused, gzip
+, jq, iana-etc, iproute, iputils, lib, libidn, libpqxx, postgresql, socat
+, utillinux
 }:
 
 let
@@ -32,6 +33,7 @@ let
         findutils # GNU find
         getconf # get num cpus
         glibcLocales # Locale information for the GNU C Library
+        gnused # GNU sed
         gnutar # GNU tar
         gzip # Gnuzip
         jq # JSON processor


### PR DESCRIPTION
# Description

Fixes https://github.com/IntersectMBO/cardano-db-sync/issues/1661

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
