### PR TITLE
fix(ci): Update hackage/chap index states

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -29,14 +29,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install GHC and Cabal
-        uses: input-output-hk/actions/devx@latest
+        uses: sgillespie/actions/devx@latest
         with:
           platform: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-linux' || 'x86_64-darwin' }}
           target-platform: ""
           compiler-nix-name: ${{ matrix.compiler-nix-name }}
           minimal: false
-          # enable IOG flavour to bring in all the crypto libraries we need.
-          iog: true
+          # enable IOG full flavour to bring in all the crypto libraries we need.
+          iog-full: true
       - name: cache cabal
         uses: actions/cache@v3
         with:

--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2024-02-06T15:14:59Z
-  , cardano-haskell-packages 2024-02-07T07:51:35Z
+  , hackage.haskell.org 2024-03-28T17:54:10Z
+  , cardano-haskell-packages 2024-03-27T12:45:54Z
 
 packages:
   cardano-db

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1707817466,
-        "narHash": "sha256-RhYwVypc8e14QlBqjkF2O7/G7J8p95xUwN5QcLo/VG4=",
+        "lastModified": 1711548043,
+        "narHash": "sha256-mO+UfcsuqEo/xRkQwxJVAjCwoMAWqm1M0mQvG4YX0z0=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "621ebfa536d0618f302ece9fb30f6cb050c9406e",
+        "rev": "f6b61b647999413d3a4f11970f53d83c95890834",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1707783775,
-        "narHash": "sha256-TkNPcAICbowXV5imZnjFrKLWJXp+e8PvEgSXm1WZos0=",
+        "lastModified": 1711585359,
+        "narHash": "sha256-dBYJqFDiwWSbLaSqQ//VEky+vy8IhmDjcT2q21e6Nys=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3518308dbe3dbc462fc69baf95b3c9acaeb47de4",
+        "rev": "85d52ecadb212b335eff7f71424021deacd855e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION




# Description

Update hackage/chap index states. In addition:

    nix flake metadata --update-input CHaP
    nix flake metadata --update-input hackageNix

This should fix #1663 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
