### PR TITLE
Fix: GitHub CI workflow - Haskell/Cabal build

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,8 +35,8 @@ jobs:
           target-platform: ""
           compiler-nix-name: ${{ matrix.compiler-nix-name }}
           minimal: false
-          # enable IOG flavour to bring in all the crypto libraries we need.
-          iog: true
+          # enable IOG-full flavour to bring in all the crypto libraries we need.
+          iog-full: true
       - name: cache cabal
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
# Description

Partially fixes #1663. The `iog` flavor of the devx GitHub action removed `postgresql`, and a new flavor was created `iog-full`, which contains `postgresql` and other extra stuff. This change updates that GitHub workflow, which _should_ fix the build

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
