### PR TITLE
Build: Add SMASH docker image

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -46,7 +46,7 @@ jobs:
           # Downcase the package repository, because docker reference
           # are required to be lower case
           REPO_OWNER="$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
-          IMAGE_TAG="$GITHUB_REF_NAME"
+          IMAGE_TAG="$(echo $GITHUB_REF_NAME | tr '/' '_')"
 
           echo "REPO_OWNER=${REPO_OWNER}" >> "$GITHUB_ENV"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"

--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -34,10 +34,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Download image from cache
-        run:
-          nix build --builders "" --max-jobs 0 .#cardano-db-sync-docker
-
       - name: Log in to ghcr.io
         uses: docker/login-action@v2.1.0
         with:
@@ -45,25 +41,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload to ghcr.io
+      - name: Set environment variables
         run: |
           # Downcase the package repository, because docker reference
           # are required to be lower case
           REPO_OWNER="$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
-          IMAGE_REF="ghcr.io/$REPO_OWNER/cardano-db-sync"
           IMAGE_TAG="$GITHUB_REF_NAME"
 
-          # Load the image from the nix build result
-          docker load < result
+          echo "REPO_OWNER=${REPO_OWNER}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
 
-          # Tag the image
-          docker image tag \
-            cardano-db-sync:latest  \
-            "${IMAGE_REF}:${IMAGE_TAG}"
+      - name: Upload ${{ github.actor }}/cardano-db-sync
+        run: |
+          # Download the image from the nix binary cachhe
+          nix build --builders "" --max-jobs 0 .#cardano-db-sync-docker
+
+          # Push the image
+          skopeo copy \
+            docker-archive:./result \
+            docker://ghcr.io/${REPO_OWNER}/cardano-db-sync:$IMAGE_TAG
+
           # Also tag it as latest
-          docker image tag \
-            cardano-db-sync:latest  \
-            "${IMAGE_REF}:latest"
-          # Push the tags above
-          docker push "${IMAGE_REF}:${IMAGE_TAG}"
-          docker push "${IMAGE_REF}:latest"
+          skopeo copy \
+            docker-archive:./result \
+            docker://ghcr.io/${REPO_OWNER}/cardano-db-sync:latest
+
+      - name: Upload ${{ github.actor }}/cardano-smash-server
+        run: |
+          # Download the image from the nix binary cachhe
+          nix build --builders "" --max-jobs 0 .#cardano-smash-server-docker
+
+          # Push the image
+          skopeo copy \
+            docker-archive:./result \
+            docker://ghcr.io/${REPO_OWNER}/cardano-smash-server:$IMAGE_TAG
+
+          # Also tag it as latest
+          skopeo copy \
+            docker-archive:./result \
+            docker://ghcr.io/${REPO_OWNER}/cardano-smash-server:latest

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -6,9 +6,11 @@
 , evalService, cardanoLib
 
 # Image dependencies
+
 , bashInteractive, cacert, cardano-cli, cardano-db-sync, cardano-db-tool
-, coreutils, curl, findutils, getconf, glibcLocales, gnutar, gzip, jq, iana-etc
-, iproute, iputils, lib, libidn, libpqxx, postgresql, socat, utillinux
+, cardano-smash-server, coreutils, curl, findutils, getconf, glibcLocales
+, gnutar, gzip, jq, iana-etc, iproute, iputils, lib, libidn, libpqxx, postgresql
+, socat, utillinux
 }:
 
 let
@@ -55,8 +57,8 @@ let
     '';
   };
 
-  # Contains cardano-db-sync binary, but no application configuration
-  imageNoConfig = dockerTools.buildImage {
+  # Contains software binaries, but no application configuration or entrypoint
+  dbSyncBaseImage = dockerTools.buildImage {
     name = "cardano-db-sync-env";
     fromImage = baseImage;
     copyToRoot = buildEnv {
@@ -66,73 +68,32 @@ let
   };
 
   # Entrypoint for the final image layer
-  entrypoint = writeScriptBin "entrypoint" ''
-    #!${runtimeShell}
-    mkdir -p /configuration
-    if [ ! -f /configuration/pgpass ]; then
-      ${genPgpass} /run/secrets
-    fi
-    export PGPASSFILE=/configuration/pgpass
-
-    # set up /tmp (override with TMPDIR variable)
-    mkdir -p -m 1777 /tmp
-    if [[ -z "$NETWORK" ]]; then
-      echo "Connecting to network specified in configuration.yaml"
-      DBSYNC=${cardano-db-sync}/bin/cardano-db-sync
-
-      set -euo pipefail
-      ${scripts.mainnet.db-sync.passthru.service.restoreSnapshotScript}
-
-      if [[ "''${DISABLE_LEDGER:-N}" == "Y" ]]; then
-        LEDGER_OPTS="--disable-ledger"
-      else
-        LEDGER_OPTS="--state-dir ${scripts.mainnet.db-sync.passthru.service.stateDir}"
-      fi
-
-      exec $DBSYNC --schema-dir ${../schema} ''${LEDGER_OPTS} $@
-
-    ${clusterStatements}
-
-    else
-      echo "Managed configuration for network "$NETWORK" does not exist"
-    fi
-  '';
-
-  # Scripts supporting entrypoint
-  genPgpass = writeScript "gen-pgpass" ''
-    #!${runtimeShell}
-    SECRET_DIR=$1
-    echo $SECRET_DIR
-    echo "Generating PGPASS file"
-    POSTGRES_DB=''${POSTGRES_DB:-$(< ''${SECRET_DIR}/postgres_db)}
-    POSTGRES_USER=''${POSTGRES_USER:-$(< ''${SECRET_DIR}/postgres_user)}
-    POSTGRES_PASSWORD=''${POSTGRES_PASSWORD:-$(< ''${SECRET_DIR}/postgres_password)}
-    echo "''${POSTGRES_HOST}:''${POSTGRES_PORT}:''${POSTGRES_DB}:''${POSTGRES_USER}:''${POSTGRES_PASSWORD}" > /configuration/pgpass
-    chmod 0600 /configuration/pgpass
-  '';
-
-  clusterStatements =
-    lib.concatStringsSep
-      "\n"
-      (lib.mapAttrsToList
-        (env: script:
-          let
-            dbSyncScript = script.db-sync;
-          in ''
-            elif [[ "$NETWORK" == "${env}" ]]; then
-              echo "Connecting to network: ${env}"
-              exec ${dbSyncScript}/bin/${dbSyncScript.name}
-              echo "Cleaning up"
-          '')
-        scripts);
-
-  scripts =
+  dbSyncEntrypoint =
     let
-      defaultConfig = {
-        services.cardano-db-sync = {
-          restoreSnapshot = lib.mkDefault "$RESTORE_SNAPSHOT";
-          socketPath = lib.mkDefault ("/node-ipc/node.socket");
-          postgres.generatePGPASS = false;
+      clusterStatements =
+        lib.concatStringsSep
+          "\n"
+          (lib.mapAttrsToList
+            (env: script:
+              let
+                dbSyncScript = script.db-sync;
+              in ''
+                elif [[ "$NETWORK" == "${env}" ]]; then
+                echo "Connecting to network: ${env}"
+                exec ${dbSyncScript}/bin/${dbSyncScript.name}
+                echo "Cleaning up"
+              '')
+            scripts);
+
+      scripts = cardanoLib.forEnvironments (env: mkScript (mkService env));
+
+      mkScript = service: lib.recurseIntoAttrs {
+        db-sync = pkgs.writeScriptBin "cardano-db-sync-${service.cluster}" ''
+          #!${runtimeShell}
+          set -euo pipefail
+          ${service.script} $@
+        '' // {
+          passthru = { inherit service; };
         };
       };
 
@@ -155,26 +116,177 @@ let
         ];
       };
 
+      defaultConfig = {
+        services.cardano-db-sync = {
+          restoreSnapshot = lib.mkDefault "$RESTORE_SNAPSHOT";
+          socketPath = lib.mkDefault ("/node-ipc/node.socket");
+          postgres.generatePGPASS = false;
+        };
+      };
+
+    in
+      writeScriptBin "entrypoint" ''
+        #!${runtimeShell}
+        mkdir -p /configuration
+        if [ ! -f /configuration/pgpass ]; then
+          ${genPgpass} /run/secrets
+        fi
+        export PGPASSFILE=/configuration/pgpass
+
+        # set up /tmp (override with TMPDIR variable)
+        mkdir -p -m 1777 /tmp
+        if [[ -z "$NETWORK" ]]; then
+          echo "Connecting to network specified in configuration.yaml"
+          DBSYNC=${cardano-db-sync}/bin/cardano-db-sync
+
+          set -euo pipefail
+          ${scripts.mainnet.db-sync.passthru.service.restoreSnapshotScript}
+
+          if [[ "''${DISABLE_LEDGER:-N}" == "Y" ]]; then
+            LEDGER_OPTS="--disable-ledger"
+          else
+            LEDGER_OPTS="--state-dir ${scripts.mainnet.db-sync.passthru.service.stateDir}"
+          fi
+
+          exec $DBSYNC --schema-dir ${../schema} ''${LEDGER_OPTS} $@
+
+        ${clusterStatements}
+        else
+          echo "Managed configuration for network "$NETWORK" does not exist"
+        fi
+      '';
+
+  # Contains software binaries, but no application configuration or entrypoint
+  smashBaseImage = dockerTools.buildImage {
+    name = "cardano-db-sync-env";
+    fromImage = baseImage;
+    copyToRoot = buildEnv {
+      name = "cardano-smash-server-image-bin-env";
+      paths = [ cardano-smash-server ];
+    };
+  };
+
+  smashEntrypoint =
+    let
+      clusterStatements =
+        lib.concatStringsSep
+          "\n"
+          (lib.mapAttrsToList
+            (env: script:
+              let
+                smashScript = script.smash;
+              in ''
+                elif [[ "$NETWORK" == "${env}" ]]; then
+                  echo "Connecting to network: ${env}"
+                  exec ${smashScript}/bin/${smashScript.name}
+                  echo "Cleaning up"
+              '')
+            scripts);
+
+      scripts = cardanoLib.forEnvironments (env: mkScript (mkService env));
+
       mkScript = service: lib.recurseIntoAttrs {
-        db-sync = pkgs.writeScriptBin "cardano-db-sync-${service.cluster}" ''
+        smash = pkgs.writeScriptBin "smash-${service.environment.name}" ''
           #!${runtimeShell}
           set -euo pipefail
           ${service.script} $@
-        '' // {
-          passthru = { inherit service; };
-        };
-      } ;
-    in
-      cardanoLib.forEnvironments (env: mkScript (mkService env));
+        '';
+      } // {
+        passthru = { inherit service; };
+      };
 
-in
-  dockerTools.buildImage {
+      mkService = env: evalService {
+        inherit pkgs;
+        customConfigs = [defaultConfig];
+        serviceName = "smash";
+
+        modules = [
+          ./nixos/smash-service.nix
+
+          {
+            services.smash = {
+              postgres.user = lib.mkDefault "*";
+              environment = lib.mkDefault env;
+              dbSyncPkgs = lib.mkDefault pkgs;
+              package = lib.mkDefault pkgs.cardano-smash-server;
+              admins = lib.mkDefault "/configuration/admins.csv";
+            };
+          }
+        ];
+      };
+
+      defaultConfig = {
+        services.smash = {
+          socketPath = lib.mkDefault "/node-ipc/node.socket";
+          postgres.generetaePGPass = false;
+        };
+      };
+
+    in
+      writeScriptBin "entrypoint" ''
+        #!${runtimeShell}
+        mkdir -p /configuration
+        if [ ! -f /configuration/pgpass ]; then
+          ${genPgpass} /run/secrets
+        fi
+        export PGPASSFILE=/configuration/pgpass
+
+        # set up /tmp (override with TMPDIR variable)
+        mkdir -p -m 1777 /tmp
+
+        # Add an admin csv
+        SMASH_USER="''${SMASH_USER:-smash-admin}"
+        SMASH_PASSWORD="''${SMASH_PASSWORD:-smash-password}"
+        echo "''${SMASH_USER},''${SMASH_PASSWORD}" > /configuration/admins.csv
+
+        # config?
+        if [[ -z "$NETWORK" ]]; then
+          echo "Connecting to network specified in configuration.yaml"
+          set -euo pipefail
+          SMASH=${cardano-smash-server}/bin/cardano-smash-server
+
+          exec $SMASH $@
+
+        ${clusterStatements}
+        else
+          echo "Managed configuration for network "$NETWORK" does not exist"
+          exec $@
+        fi
+      '';
+
+  # Scripts supporting entrypoint
+  genPgpass = writeScript "gen-pgpass" ''
+    #!${runtimeShell}
+    SECRET_DIR=$1
+    echo $SECRET_DIR
+    echo "Generating PGPASS file"
+    POSTGRES_DB=''${POSTGRES_DB:-$(< ''${SECRET_DIR}/postgres_db)}
+    POSTGRES_USER=''${POSTGRES_USER:-$(< ''${SECRET_DIR}/postgres_user)}
+    POSTGRES_PASSWORD=''${POSTGRES_PASSWORD:-$(< ''${SECRET_DIR}/postgres_password)}
+    echo "''${POSTGRES_HOST}:''${POSTGRES_PORT}:''${POSTGRES_DB}:''${POSTGRES_USER}:''${POSTGRES_PASSWORD}" > /configuration/pgpass
+    chmod 0600 /configuration/pgpass
+  '';
+
+in {
+  cardano-db-sync-docker = dockerTools.buildImage {
     name = "cardano-db-sync";
-    fromImage = imageNoConfig;
+    fromImage = dbSyncBaseImage;
     tag = "latest";
     copyToRoot = buildEnv {
       name = "cardano-db-sync-entrypoint";
-      paths = [ entrypoint bashInteractive ];
+      paths = [ dbSyncEntrypoint bashInteractive ];
     };
-    config = { Entrypoint = [ "${entrypoint}/bin/entrypoint" ]; };
-  }
+    config = { Entrypoint = [ "${dbSyncEntrypoint}/bin/entrypoint" ]; };
+  };
+
+  cardano-smash-server-docker = dockerTools.buildImage {
+    name = "cardano-smash-server";
+    fromImage = smashBaseImage;
+    tag = "latest";
+    copyToRoot = buildEnv {
+      name = "cardano-smash-server-entrypoint";
+      paths = [ smashEntrypoint bashInteractive ];
+    };
+    config = { Entrypoint = [ "${smashEntrypoint}/bin/entrypoint" ]; };
+  };
+}


### PR DESCRIPTION
# Description

Partially fixes #1649. Adds a new image `cardano-smash-server` and a ghcr.io image registry. It should follow all of the conventions established in the `cardano-db-sync` image, which means it will accept variables for:

 * NETWORK
 * POSTGRES_USER
 * POSTGRES_PASSWORD
 * POSTGRES_HOST
 * POSTGRES_PORT

Furthermore, we add the following variables:

 * SMASH_USER
 * SMASH_PASSWORD

To generate the credentials for basic authentication.

After this is merged, I will backport this to previous released 13.2.x and 13.1.x.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
