### PR TITLE
Fix: Cleanup macOS pre-installed libraries

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,6 +37,11 @@ jobs:
           minimal: false
           # enable IOG-full flavour to bring in all the crypto libraries we need.
           iog-full: true
+      - name: "macOS: clean up pre-installed libraries"
+        if: runner.os == 'macOS'
+        # Homebrew's icu4c conflics with Nix's
+        run: |
+          brew uninstall --ignore-dependencies icu4c
       - name: cache cabal
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
# Description

Fixes #1663. The Github Actions runner for macOS ships with `icu4c` that conflicts with Nix's. In particular the text-icu Hackage package explicitly adds Homebrew's lib-dirs. With this change, we uninstall the package from Homebrew, forcing the version from nix to be used.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
