### PR TITLE
Feature: Add optional "enable_conway" config flag

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
@@ -33,6 +33,9 @@ unitTests iom knownMigrations =
         , testCase "mismatched conway genesis hash" Config.wrongConwayGenesisHash
         , testCase "default insert config" Config.defaultInsertConfig
         , testCase "insert config" Config.insertConfig
+        , testCase "disable conway" Config.disableConway
+        , testCase "enable conway" Config.enableConway
+        , testCase "enable conway by default" Config.enableConwayDefault
         , testGroup
             "tx-out"
             [ test "consumed_by_tx_id column check" MigrateConsumedPruneTxOut.txConsumedColumnCheck

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Config/Parse.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Config/Parse.hs
@@ -8,6 +8,9 @@ module Test.Cardano.Db.Mock.Unit.Conway.Config.Parse (
   wrongConwayGenesisHash,
   insertConfig,
   defaultInsertConfig,
+  disableConway,
+  enableConway,
+  enableConwayDefault,
 ) where
 
 import Cardano.DbSync.Config
@@ -106,3 +109,52 @@ insertConfig = do
   dncInsertOptions cfg @?= expected
   where
     configDir = "config-conway-insert-options"
+
+disableConway :: Assertion
+disableConway = do
+  cfg <- mkSyncNodeConfig configDir args
+
+  -- Make the conway genesis invalid
+  hash <- Aeson.throwDecode "\"0000000000000000000000000000000000000000000000000000000000000000\""
+  let cfg' = cfg {dncConwayGenesisHash = Just hash}
+  -- Should not throw
+  void $ mkConfig configDir mutableDir args cfg'
+  where
+    configDir = "config-conway"
+    mutableDir = mkMutableDir "configDisableConway"
+    args =
+      initCommandLineArgs
+        { claConfigFilename = "test-db-sync-config-disable-conway.json"
+        }
+
+enableConway :: Assertion
+enableConway = do
+  cfg <- mkSyncNodeConfig configDir args
+
+  -- There's no way to verify the file was actually loaded
+  isJust (dncConwayGenesisHash cfg) @?= True
+  isJust (dncConwayGenesisFile cfg) @?= True
+
+  -- Should not throw
+  void $ mkConfig configDir mutableDir args cfg
+  where
+    configDir = "config-conway"
+    mutableDir = mkMutableDir "configDisableConway"
+    args =
+      initCommandLineArgs
+        { claConfigFilename = "test-db-sync-config-enable-conway.json"
+        }
+
+enableConwayDefault :: Assertion
+enableConwayDefault = do
+  cfg <- mkSyncNodeConfig configDir initCommandLineArgs
+
+  -- There's no way to verify the file was actually loaded
+  isJust (dncConwayGenesisHash cfg) @?= True
+  isJust (dncConwayGenesisFile cfg) @?= True
+
+  -- Should not throw
+  void $ mkConfig configDir mutableDir initCommandLineArgs cfg
+  where
+    configDir = "config-conway"
+    mutableDir = mkMutableDir "configDisableConway"

--- a/cardano-chain-gen/test/testfiles/config-conway/test-db-sync-config-disable-conway.json
+++ b/cardano-chain-gen/test/testfiles/config-conway/test-db-sync-config-disable-conway.json
@@ -1,0 +1,115 @@
+{
+  "EnableLogMetrics": false,
+  "EnableLogging": true,
+  "NetworkName": "testing",
+  "NodeConfigFile": "test-config.json",
+  "PrometheusPort": 8080,
+  "RequiresNetworkMagic": "RequiresMagic",
+  "defaultBackends": [
+    "KatipBK"
+  ],
+  "defaultScribes": [
+    [
+      "StdoutSK",
+      "stdout"
+    ]
+  ],
+  "minSeverity": "Info",
+  "options": {
+    "cfokey": {
+      "value": "Release-1.0.0"
+    },
+    "mapBackends": {},
+    "mapSeverity": {
+      "db-sync-node": "Info",
+      "db-sync-node.Mux": "Error",
+      "db-sync-node.Subscription": "Error"
+    },
+    "mapSubtrace": {
+      "#ekgview": {
+        "contents": [
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": ".monoclock.basic.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": "diff.RTS.cpuNs.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
+              "tag": "StartsWith"
+            },
+            [
+              {
+                "contents": "diff.RTS.gcNum.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ]
+        ],
+        "subtrace": "FilterTrace"
+      },
+      "#messagecounters.aggregation": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.ekgview": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.katip": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.monitoring": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.switchboard": {
+        "subtrace": "NoTrace"
+      },
+      "benchmark": {
+        "contents": [
+          "GhcRtsStats",
+          "MonotonicClock"
+        ],
+        "subtrace": "ObservableTrace"
+      },
+      "cardano.epoch-validation.utxo-stats": {
+        "subtrace": "NoTrace"
+      }
+    }
+  },
+  "rotation": {
+    "rpKeepFilesNum": 10,
+    "rpLogLimitBytes": 5000000,
+    "rpMaxAgeHours": 24
+  },
+  "setupBackends": [
+    "AggregationBK",
+    "KatipBK"
+  ],
+  "setupScribes": [
+    {
+      "scFormat": "ScText",
+      "scKind": "StdoutSK",
+      "scName": "stdout",
+      "scRotation": null
+    }
+  ],
+  "enable_conway": false
+}

--- a/cardano-chain-gen/test/testfiles/config-conway/test-db-sync-config-enable-conway.json
+++ b/cardano-chain-gen/test/testfiles/config-conway/test-db-sync-config-enable-conway.json
@@ -1,0 +1,115 @@
+{
+  "EnableLogMetrics": false,
+  "EnableLogging": true,
+  "NetworkName": "testing",
+  "NodeConfigFile": "test-config.json",
+  "PrometheusPort": 8080,
+  "RequiresNetworkMagic": "RequiresMagic",
+  "defaultBackends": [
+    "KatipBK"
+  ],
+  "defaultScribes": [
+    [
+      "StdoutSK",
+      "stdout"
+    ]
+  ],
+  "minSeverity": "Info",
+  "options": {
+    "cfokey": {
+      "value": "Release-1.0.0"
+    },
+    "mapBackends": {},
+    "mapSeverity": {
+      "db-sync-node": "Info",
+      "db-sync-node.Mux": "Error",
+      "db-sync-node.Subscription": "Error"
+    },
+    "mapSubtrace": {
+      "#ekgview": {
+        "contents": [
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": ".monoclock.basic.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": "diff.RTS.cpuNs.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
+              "tag": "StartsWith"
+            },
+            [
+              {
+                "contents": "diff.RTS.gcNum.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ]
+        ],
+        "subtrace": "FilterTrace"
+      },
+      "#messagecounters.aggregation": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.ekgview": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.katip": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.monitoring": {
+        "subtrace": "NoTrace"
+      },
+      "#messagecounters.switchboard": {
+        "subtrace": "NoTrace"
+      },
+      "benchmark": {
+        "contents": [
+          "GhcRtsStats",
+          "MonotonicClock"
+        ],
+        "subtrace": "ObservableTrace"
+      },
+      "cardano.epoch-validation.utxo-stats": {
+        "subtrace": "NoTrace"
+      }
+    }
+  },
+  "rotation": {
+    "rpKeepFilesNum": 10,
+    "rpLogLimitBytes": 5000000,
+    "rpMaxAgeHours": 24
+  },
+  "setupBackends": [
+    "AggregationBK",
+    "KatipBK"
+  ],
+  "setupScribes": [
+    {
+      "scFormat": "ScText",
+      "scKind": "StdoutSK",
+      "scName": "stdout",
+      "scRotation": null
+    }
+  ],
+  "enable_conway": true
+}

--- a/cardano-db-sync/src/Cardano/DbSync/Config.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config.hs
@@ -58,6 +58,11 @@ coalesceConfig ::
   IO SyncNodeConfig
 coalesceConfig pcfg ncfg adjustGenesisPath = do
   lc <- Logging.setupFromRepresentation $ pcLoggingConfig pcfg
+
+  let (conwayGenesisFile', conwayGenesisHash')
+        | pcEnableConway pcfg = (ncConwayGenesisFile ncfg, ncConwayGenesisHash ncfg)
+        | otherwise = (Nothing, Nothing)
+
   pure $
     SyncNodeConfig
       { dncNetworkName = pcNetworkName pcfg
@@ -76,8 +81,8 @@ coalesceConfig pcfg ncfg adjustGenesisPath = do
       , dncAlonzoGenesisFile = adjustGenesisFilePath adjustGenesisPath (ncAlonzoGenesisFile ncfg)
       , dncAlonzoGenesisHash = ncAlonzoGenesisHash ncfg
       , dncConwayGenesisFile =
-          adjustGenesisFilePath adjustGenesisPath <$> ncConwayGenesisFile ncfg
-      , dncConwayGenesisHash = ncConwayGenesisHash ncfg
+          adjustGenesisFilePath adjustGenesisPath <$> conwayGenesisFile'
+      , dncConwayGenesisHash = conwayGenesisHash'
       , dncByronProtocolVersion = ncByronProtocolVersion ncfg
       , dncShelleyHardFork = ncShelleyHardFork ncfg
       , dncAllegraHardFork = ncAllegraHardFork ncfg

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
@@ -143,6 +143,7 @@ data SyncPreConfig = SyncPreConfig
   , pcEnableMetrics :: !Bool
   , pcPrometheusPort :: !Int
   , pcInsertConfig :: !SyncInsertConfig
+  , pcEnableConway :: !Bool
   }
   deriving (Show)
 
@@ -356,6 +357,7 @@ parseGenSyncNodeConfig o =
     <*> o .: "EnableLogMetrics"
     <*> fmap (fromMaybe 8080) (o .:? "PrometheusPort")
     <*> o .:? "insert_options" .!= def
+    <*> o .:? "enable_conway" .!= True
 
 instance FromJSON SyncProtocol where
   parseJSON o =

--- a/cardano-db-sync/test/Cardano/DbSync/Gen.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/Gen.hs
@@ -54,6 +54,7 @@ syncPreConfig =
     <*> Gen.bool
     <*> Gen.int (Range.linear 0 10000)
     <*> syncInsertConfig
+    <*> Gen.bool
 
 syncNodeParams :: MonadGen m => m SyncNodeParams
 syncNodeParams =


### PR DESCRIPTION
# Description

Adds a new optional configuration flag `enable_conway`, which defaults to true. This should allow us to ignore frequently changing conway genesis in mainnet configs

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
