### PR TITLE
Save the DRep Pulser State after computing it

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
@@ -218,9 +218,45 @@ instance HasNewEpochState StandardShelley where
     hApplyExtLedgerState $
       fn (applyNewEpochState' st) :* fn id :* fn id :* fn id :* fn id :* fn id :* Nil
 
+instance HasNewEpochState StandardAllegra where
+  getNewEpochState st = case ledgerState st of
+    LedgerStateAllegra allegra -> Just (shelleyLedgerState allegra)
+    _ -> Nothing
+
+  applyNewEpochState st =
+    hApplyExtLedgerState $
+      fn id :* fn (applyNewEpochState' st) :* fn id :* fn id :* fn id :* fn id :* Nil
+
+instance HasNewEpochState StandardMary where
+  getNewEpochState st = case ledgerState st of
+    LedgerStateMary mary -> Just (shelleyLedgerState mary)
+    _ -> Nothing
+
+  applyNewEpochState st =
+    hApplyExtLedgerState $
+      fn id :* fn id :* fn (applyNewEpochState' st) :* fn id :* fn id :* fn id :* Nil
+
+instance HasNewEpochState StandardAlonzo where
+  getNewEpochState st = case ledgerState st of
+    LedgerStateAlonzo alonzo -> Just (shelleyLedgerState alonzo)
+    _ -> Nothing
+
+  applyNewEpochState st =
+    hApplyExtLedgerState $
+      fn id :* fn id :* fn id :* fn (applyNewEpochState' st) :* fn id :* fn id :* Nil
+
+instance HasNewEpochState StandardBabbage where
+  getNewEpochState st = case ledgerState st of
+    LedgerStateBabbage babbage -> Just (shelleyLedgerState babbage)
+    _ -> Nothing
+
+  applyNewEpochState st =
+    hApplyExtLedgerState $
+      fn id :* fn id :* fn id :* fn id :* fn (applyNewEpochState' st) :* fn id :* Nil
+
 instance HasNewEpochState StandardConway where
   getNewEpochState st = case ledgerState st of
-    LedgerStateConway shelley -> Just (shelleyLedgerState shelley)
+    LedgerStateConway conway -> Just (shelleyLedgerState conway)
     _ -> Nothing
 
   applyNewEpochState st =

--- a/cardano-db-sync/src/Cardano/DbSync/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Types.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Cardano.DbSync.Types (
   BlockDetails (..),
@@ -53,6 +55,7 @@ import qualified Cardano.Ledger.Credential as Ledger
 import Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Hashes as Ledger
 import Cardano.Ledger.Keys
+
 import Cardano.Prelude hiding (Meta, show)
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
 import qualified Data.Text as Text


### PR DESCRIPTION
# Description

Fixes #1599. The bulk of this work is done in the `HasNewEpochState` typeclass, which allows us to update the ledger state in `ExtLedgerState`. 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
