### PR TITLE
Nix: Add "profiled" builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,34 @@
-dist-newstyle/
+# Haskell
+.ghc.environment.*
 .stack-work/
-dist
-*.swp
-log-dir
-result*
-launch_*
 cabal.project.local
-gen/
-/.vscode
-.DS_Store
+dist-newstyle/
+dist
 
+*.prof
+*.aux
+*.hp
+*.eventlog
+
+log-dir
+launch_*
+gen/
 cardano-chain-gen/test/testfiles/temp/
 /secp256k1/
 
-.ghc.environment.*
+# Vim
+*.swp
+
+# Emacs
+.dir-locals.el
+
+# Nix
+.direnv
+.envrc
+result*
+
+# VS Code
+/.vscode
+
+# MacOS
+.DS_Store

--- a/flake.nix
+++ b/flake.nix
@@ -319,6 +319,23 @@
             };
             inherit (docker) cardano-db-sync-docker cardano-smash-server-docker;
 
+            profiled =
+              let
+                projectProfiled = (project.appendModule {
+                  modules = [{
+                    enableLibraryProfiling = true;
+                    enableProfiling = true;
+                    packages.cardano-db-sync.configureFlags =
+                      ["--ghc-option=-fprof-auto"];
+                    packages.cardano-smash-server.configureFlags =
+                      ["--ghc-option=-fprof-auto"];
+
+                  }];
+                });
+              in {
+                inherit (projectProfiled.exes) cardano-db-sync cardano-smash-server;
+              };
+
             # TODO: macOS builders are resource-constrained and cannot run the detabase
             # integration tests. Add these back when we get beefier builders.
             nonRequiredMacOSPaths = [
@@ -347,7 +364,8 @@
             } // lib.optionalAttrs (system == "x86_64-darwin") {
               inherit cardano-db-sync-macos;
             } // {
-              inherit cardano-smash-server-no-basic-auth;
+              inherit cardano-smash-server-no-basic-auth profiled;
+
               checks = staticChecks;
             };
 
@@ -364,7 +382,7 @@
             } // lib.optionalAttrs (system == "x86_64-darwin") {
               inherit cardano-db-sync-macos;
             } // {
-              inherit cardano-smash-server-no-basic-auth;
+              inherit cardano-smash-server-no-basic-auth profiled;
             };
           })) // {
             nixosModules = {


### PR DESCRIPTION
# Description

Add profiled builds for `cardano-db-sync` and `cardano-smash-server`

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
