### PR TITLE
Add profiling options to NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -399,7 +399,11 @@
                   let
                     pkgs' = self.legacyPackages.${pkgs.system};
                   in {
-                    inherit (pkgs') cardanoLib schema cardano-db-sync;
+                    inherit (pkgs')
+                      cardanoLib
+                      schema
+                      cardano-db-sync
+                      cardano-db-sync-profiled;
 
                     # cardano-db-tool
                     cardanoDbSyncHaskellPackages.cardano-db-tool.components.exes.cardano-db-tool =


### PR DESCRIPTION
# Description

This change adds multiple options to the NixOS module:

 * `profiling` (`boolean`)
 * `rtsArgs` (`list` of `string`)

If `profiling` is enabled, then rtsArgs defaults to some sensible heap profiling options.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
