### PR TITLE
Rename Cache type to CacheStatus

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -55,7 +55,7 @@ import qualified Cardano.Chain.Genesis as Byron
 import Cardano.Crypto.ProtocolMagic (ProtocolMagicId (..))
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api.Types
-import Cardano.DbSync.Cache.Types (newEmptyCache, uninitiatedCache)
+import Cardano.DbSync.Cache.Types (newEmptyCache, useNoCache)
 import Cardano.DbSync.Config.Cardano
 import Cardano.DbSync.Config.Shelley
 import Cardano.DbSync.Config.Types
@@ -382,7 +382,7 @@ mkSyncEnv ::
   IO SyncEnv
 mkSyncEnv trce backend connectionString syncOptions protoInfo nw nwMagic systemStart syncNodeConfigFromFile syncNP ranMigrations runMigrationFnc = do
   dbCNamesVar <- newTVarIO =<< dbConstraintNamesExists backend
-  cache <- if soptCache syncOptions then newEmptyCache 250000 50000 else pure uninitiatedCache
+  cache <- if soptCache syncOptions then newEmptyCache 250000 50000 else pure useNoCache
   consistentLevelVar <- newTVarIO Unchecked
   fixDataVar <- newTVarIO $ if ranMigrations then DataFixRan else NoneFixRan
   indexesVar <- newTVarIO $ enpForceIndexes syncNP

--- a/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
@@ -14,7 +14,7 @@ module Cardano.DbSync.Api.Types (
 ) where
 
 import qualified Cardano.Db as DB
-import Cardano.DbSync.Cache.Types (Cache)
+import Cardano.DbSync.Cache.Types (CacheStatus)
 import Cardano.DbSync.Config.Types (SyncNodeConfig)
 import Cardano.DbSync.Ledger.Types (HasLedgerEnv)
 import Cardano.DbSync.LocalStateQuery (NoLedgerEnv)
@@ -39,7 +39,7 @@ import Ouroboros.Network.Magic (NetworkMagic (..))
 
 data SyncEnv = SyncEnv
   { envBackend :: !SqlBackend
-  , envCache :: !Cache
+  , envCache :: !CacheStatus
   , envConnectionString :: !ConnectionString
   , envConsistentLevel :: !(StrictTVar IO ConsistentLevel)
   , envDbConstraints :: !(StrictTVar IO DB.ManualDbConstraints)

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
@@ -7,7 +7,7 @@
 
 module Cardano.DbSync.Cache.Types (
   CacheStatus (..),
-  CacheNew (..),
+  CacheUpdateAction (..),
   CacheEpoch (..),
   CacheInternal (..),
   EpochBlockDiff (..),
@@ -50,10 +50,10 @@ data CacheStatus
   = NoCache
   | ActiveCache !CacheInternal
 
-data CacheNew
-  = CacheNew
-  | DontCacheNew
-  | EvictAndReturn
+data CacheUpdateAction
+  = UpdateCache
+  | DoNotUpdateCache
+  | EvictAndUpdateCache
   deriving (Eq)
 
 data CacheInternal = CacheInternal

--- a/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
@@ -13,7 +13,7 @@ import qualified Cardano.Db as DB
 import Cardano.DbSync.Api (getTrace)
 import Cardano.DbSync.Api.Types (SyncEnv)
 import Cardano.DbSync.Cache.Epoch (readEpochBlockDiffFromCache, readLastMapEpochFromCache, writeToMapEpochCache)
-import Cardano.DbSync.Cache.Types (Cache (..), EpochBlockDiff (..))
+import Cardano.DbSync.Cache.Types (CacheStatus (..), EpochBlockDiff (..))
 import Cardano.DbSync.Error
 import Cardano.DbSync.Types (
   BlockDetails (BlockDetails),
@@ -38,7 +38,7 @@ import Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
 epochHandler ::
   SyncEnv ->
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   Bool ->
   BlockDetails ->
   ReaderT SqlBackend (LoggingT IO) (Either SyncNodeError ())
@@ -71,7 +71,7 @@ epochHandler syncEnv trce cache isNewEpochEvent (BlockDetails cblk details) =
 
 updateEpochStart ::
   SyncEnv ->
-  Cache ->
+  CacheStatus ->
   SlotDetails ->
   Bool ->
   Bool ->
@@ -106,7 +106,7 @@ updateEpochStart syncEnv cache slotDetails isNewEpochEvent isBoundaryBlock = do
 handleEpochWhenFollowing ::
   (MonadBaseControl IO m, MonadIO m) =>
   SyncEnv ->
-  Cache ->
+  CacheStatus ->
   Maybe DB.Epoch ->
   Maybe EpochBlockDiff ->
   Word64 ->
@@ -141,7 +141,7 @@ handleEpochWhenFollowing syncEnv cache newestEpochFromMap epochBlockDiffCache ep
 makeEpochWithCacheWhenFollowing ::
   (MonadBaseControl IO m, MonadIO m) =>
   SyncEnv ->
-  Cache ->
+  CacheStatus ->
   DB.Epoch ->
   EpochBlockDiff ->
   Word64 ->
@@ -168,7 +168,7 @@ makeEpochWithCacheWhenFollowing syncEnv cache newestEpochFromMapache currentEpCa
 updateEpochWhenSyncing ::
   (MonadBaseControl IO m, MonadIO m) =>
   SyncEnv ->
-  Cache ->
+  CacheStatus ->
   Maybe EpochBlockDiff ->
   Maybe DB.Epoch ->
   Word64 ->
@@ -213,7 +213,7 @@ updateEpochWhenSyncing syncEnv cache mEpochBlockDiff mLastMapEpochFromCache epoc
 handleEpochCachingWhenSyncing ::
   (MonadBaseControl IO m, MonadIO m) =>
   SyncEnv ->
-  Cache ->
+  CacheStatus ->
   Maybe DB.Epoch ->
   Maybe EpochBlockDiff ->
   ReaderT SqlBackend m (Either SyncNodeError ())
@@ -239,7 +239,7 @@ handleEpochCachingWhenSyncing syncEnv cache newestEpochFromMap epochBlockDiffCac
 makeEpochWithDBQuery ::
   (MonadBaseControl IO m, MonadIO m) =>
   SyncEnv ->
-  Cache ->
+  CacheStatus ->
   Maybe DB.Epoch ->
   Word64 ->
   Text ->

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -26,7 +26,7 @@ import Cardano.DbSync.Cache (
   queryPrevBlockWithCache,
  )
 import Cardano.DbSync.Cache.Epoch (writeEpochBlockDiffToCache)
-import Cardano.DbSync.Cache.Types (Cache (..), EpochBlockDiff (..))
+import Cardano.DbSync.Cache.Types (CacheStatus (..), EpochBlockDiff (..))
 import qualified Cardano.DbSync.Era.Byron.Util as Byron
 import Cardano.DbSync.Era.Util (liftLookupFail)
 import Cardano.DbSync.Error
@@ -216,7 +216,7 @@ insertABlock syncEnv firstBlockOfEpoch blk details = do
     tracer :: Trace IO Text
     tracer = getTrace syncEnv
 
-    cache :: Cache
+    cache :: CacheStatus
     cache = envCache syncEnv
 
     logger :: Bool -> Trace IO a -> a -> IO ()

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Adjust.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Adjust.hs
@@ -13,7 +13,7 @@ import Cardano.DbSync.Cache (
   queryPoolKeyWithCache,
   queryStakeAddrWithCache,
  )
-import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus)
+import Cardano.DbSync.Cache.Types (CacheStatus, CacheUpdateAction (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic.Rewards as Generic
 import Cardano.DbSync.Types (StakeCred)
 import Cardano.Ledger.BaseTypes (Network)
@@ -67,7 +67,7 @@ adjustEpochRewards tracer nw cache epochNo rwds creds = do
   forM_ eraIgnored $ \(cred, rewards) ->
     forM_ (Set.toList rewards) $ \rwd ->
       deleteReward nw cache epochNo (cred, rwd)
-  crds <- rights <$> forM (Set.toList creds) (queryStakeAddrWithCache cache DontCacheNew nw)
+  crds <- rights <$> forM (Set.toList creds) (queryStakeAddrWithCache cache DoNotUpdateCache nw)
   deleteOrphanedRewards epochNo crds
 
 deleteReward ::
@@ -78,8 +78,8 @@ deleteReward ::
   (StakeCred, Generic.Reward) ->
   ReaderT SqlBackend m ()
 deleteReward nw cache epochNo (cred, rwd) = do
-  mAddrId <- queryStakeAddrWithCache cache DontCacheNew nw cred
-  eiPoolId <- queryPoolKeyWithCache cache DontCacheNew (Generic.rewardPool rwd)
+  mAddrId <- queryStakeAddrWithCache cache DoNotUpdateCache nw cred
+  eiPoolId <- queryPoolKeyWithCache cache DoNotUpdateCache (Generic.rewardPool rwd)
   case (mAddrId, eiPoolId) of
     (Right addrId, Right poolId) -> do
       delete $ do

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Adjust.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Adjust.hs
@@ -13,7 +13,7 @@ import Cardano.DbSync.Cache (
   queryPoolKeyWithCache,
   queryStakeAddrWithCache,
  )
-import Cardano.DbSync.Cache.Types (Cache, CacheNew (..))
+import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus)
 import qualified Cardano.DbSync.Era.Shelley.Generic.Rewards as Generic
 import Cardano.DbSync.Types (StakeCred)
 import Cardano.Ledger.BaseTypes (Network)
@@ -50,7 +50,7 @@ adjustEpochRewards ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
   Network ->
-  Cache ->
+  CacheStatus ->
   EpochNo ->
   Generic.Rewards ->
   Set StakeCred ->
@@ -73,7 +73,7 @@ adjustEpochRewards tracer nw cache epochNo rwds creds = do
 deleteReward ::
   (MonadBaseControl IO m, MonadIO m) =>
   Network ->
-  Cache ->
+  CacheStatus ->
   EpochNo ->
   (StakeCred, Generic.Reward) ->
   ReaderT SqlBackend m ()

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
@@ -21,7 +21,7 @@ import Cardano.DbSync.Cache (
   queryPrevBlockWithCache,
  )
 import Cardano.DbSync.Cache.Epoch (writeEpochBlockDiffToCache)
-import Cardano.DbSync.Cache.Types (Cache (..), CacheNew (..), EpochBlockDiff (..))
+import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..), EpochBlockDiff (..))
 
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Universal.Epoch
@@ -181,5 +181,5 @@ insertBlockUniversal syncEnv shouldLog withinTwoMins withinHalfHour blk details 
     tracer :: Trace IO Text
     tracer = getTrace syncEnv
 
-    cache :: Cache
+    cache :: CacheStatus
     cache = envCache syncEnv

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
@@ -21,7 +21,7 @@ import Cardano.DbSync.Cache (
   queryPrevBlockWithCache,
  )
 import Cardano.DbSync.Cache.Epoch (writeEpochBlockDiffToCache)
-import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..), EpochBlockDiff (..))
+import Cardano.DbSync.Cache.Types (CacheStatus (..), CacheUpdateAction (..), EpochBlockDiff (..))
 
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Universal.Epoch
@@ -67,13 +67,13 @@ insertBlockUniversal syncEnv shouldLog withinTwoMins withinHalfHour blk details 
   runExceptT $ do
     pbid <- case Generic.blkPreviousHash blk of
       Nothing -> liftLookupFail (renderErrorMessage (Generic.blkEra blk)) DB.queryGenesis -- this is for networks that fork from Byron on epoch 0.
-      Just pHash -> queryPrevBlockWithCache (renderErrorMessage (Generic.blkEra blk)) cache pHash
-    mPhid <- lift $ queryPoolKeyWithCache cache CacheNew $ coerceKeyRole $ Generic.blkSlotLeader blk
+      Just pHash -> queryPrevBlockWithCache (renderErrorMessage (Generic.blkEra blk)) cacheStatus pHash
+    mPhid <- lift $ queryPoolKeyWithCache cacheStatus UpdateCache $ coerceKeyRole $ Generic.blkSlotLeader blk
     let epochNo = sdEpochNo details
 
     slid <- lift . DB.insertSlotLeader $ Generic.mkSlotLeader (ioShelley iopts) (Generic.unKeyHashRaw $ Generic.blkSlotLeader blk) (eitherToMaybe mPhid)
     blkId <-
-      lift . insertBlockAndCache cache $
+      lift . insertBlockAndCache cacheStatus $
         DB.Block
           { DB.blockHash = Generic.blkHash blk
           , DB.blockEpochNo = Just $ unEpochNo epochNo
@@ -104,7 +104,7 @@ insertBlockUniversal syncEnv shouldLog withinTwoMins withinHalfHour blk details 
     when (soptEpochAndCacheEnabled $ envOptions syncEnv)
       . newExceptT
       $ writeEpochBlockDiffToCache
-        cache
+        cacheStatus
         EpochBlockDiff
           { ebdBlockId = blkId
           , ebdTime = sdSlotTime details
@@ -181,5 +181,5 @@ insertBlockUniversal syncEnv shouldLog withinTwoMins withinHalfHour blk details 
     tracer :: Trace IO Text
     tracer = getTrace syncEnv
 
-    cache :: CacheStatus
-    cache = envCache syncEnv
+    cacheStatus :: CacheStatus
+    cacheStatus = envCache syncEnv

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Epoch.hs
@@ -26,7 +26,7 @@ import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
 import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv (..))
 import Cardano.DbSync.Cache (queryOrInsertStakeAddress, queryPoolKeyOrInsert)
-import Cardano.DbSync.Cache.Types (Cache, CacheNew (..))
+import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus)
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Universal.Insert.Certificate (insertPots)
 import Cardano.DbSync.Era.Universal.Insert.GovAction (insertCostModel, insertDrepDistr, insertUpdateEnacted, updateExpired, updateRatified)
@@ -210,7 +210,7 @@ insertEpochStake syncEnv nw epochNo stakeChunk = do
   where
     mkStake ::
       (MonadBaseControl IO m, MonadIO m) =>
-      Cache ->
+      CacheStatus ->
       (StakeCred, (Shelley.Coin, PoolKeyHash)) ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) DB.EpochStake
     mkStake cache (saddr, (coin, pool)) = do
@@ -233,7 +233,7 @@ insertRewards ::
   Network ->
   EpochNo ->
   EpochNo ->
-  Cache ->
+  CacheStatus ->
   [(StakeCred, Set Generic.Reward)] ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertRewards syncEnv nw earnedEpoch spendableEpoch cache rewardsChunk = do
@@ -283,7 +283,7 @@ insertRewardRests ::
   Network ->
   EpochNo ->
   EpochNo ->
-  Cache ->
+  CacheStatus ->
   [(StakeCred, Set Generic.RewardRest)] ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertRewardRests nw earnedEpoch spendableEpoch cache rewardsChunk = do
@@ -318,7 +318,7 @@ insertProposalRefunds ::
   Network ->
   EpochNo ->
   EpochNo ->
-  Cache ->
+  CacheStatus ->
   [GovActionRefunded] ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertProposalRefunds nw earnedEpoch spendableEpoch cache refunds = do

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Certificate.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Certificate.hs
@@ -31,7 +31,7 @@ import Cardano.DbSync.Cache (
   queryOrInsertStakeAddress,
   queryPoolKeyOrInsert,
  )
-import Cardano.DbSync.Cache.Types (Cache (..), CacheNew (..))
+import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Universal.Insert.GovAction (insertCommitteeHash, insertCredDrepHash, insertDrep, insertVotingAnchor)
 import Cardano.DbSync.Era.Universal.Insert.Pool (IsPoolMember, insertPoolCert)
@@ -107,7 +107,7 @@ insertCertificate syncEnv isMember mDeposits blkId txId epochNo slotNo redeemers
 insertDelegCert ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   Maybe Generic.Deposits ->
   Ledger.Network ->
   DB.TxId ->
@@ -171,7 +171,7 @@ insertConwayDelegCert syncEnv mDeposits txId idx mRedeemerId epochNo slotNo dCer
 insertMirCert ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   Ledger.Network ->
   DB.TxId ->
   Word16 ->
@@ -316,7 +316,7 @@ insertCommitteeDeRegistration blockId txId idx khCold mAnchor = do
 
 insertStakeDeregistration ::
   (MonadBaseControl IO m, MonadIO m) =>
-  Cache ->
+  CacheStatus ->
   Ledger.Network ->
   EpochNo ->
   DB.TxId ->
@@ -402,7 +402,7 @@ mkAdaPots blockId slotNo epochNo pots =
 insertDelegation ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   Ledger.Network ->
   EpochNo ->
   SlotNo ->
@@ -428,7 +428,7 @@ insertDelegation trce cache network (EpochNo epoch) slotNo txId idx mRedeemerId 
 
 insertDelegationVote ::
   (MonadBaseControl IO m, MonadIO m) =>
-  Cache ->
+  CacheStatus ->
   Ledger.Network ->
   DB.TxId ->
   Word16 ->

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/GovAction.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/GovAction.hs
@@ -33,7 +33,7 @@ import qualified Cardano.Crypto as Crypto
 import Cardano.Db (DbWord64 (..))
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Cache (queryOrInsertRewardAccount, queryPoolKeyOrInsert)
-import Cardano.DbSync.Cache.Types (Cache (..), CacheNew (..))
+import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Shelley.Generic.ParamProposal
 import Cardano.DbSync.Era.Universal.Insert.Other (toDouble)
@@ -69,7 +69,7 @@ import Ouroboros.Consensus.Cardano.Block (StandardConway, StandardCrypto)
 insertGovActionProposal ::
   forall m.
   (MonadIO m, MonadBaseControl IO m) =>
-  Cache ->
+  CacheStatus ->
   DB.BlockId ->
   DB.TxId ->
   Maybe EpochNo ->
@@ -270,7 +270,7 @@ insertConstitution blockId mgapId constitution = do
 insertVotingProcedures ::
   (MonadIO m, MonadBaseControl IO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   DB.BlockId ->
   DB.TxId ->
   (Voter StandardCrypto, [(GovActionId StandardCrypto, VotingProcedure StandardConway)]) ->
@@ -281,7 +281,7 @@ insertVotingProcedures trce cache blkId txId (voter, actions) =
 insertVotingProcedure ::
   (MonadIO m, MonadBaseControl IO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   DB.BlockId ->
   DB.TxId ->
   Voter StandardCrypto ->

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
@@ -21,7 +21,7 @@ module Cardano.DbSync.Era.Universal.Insert.Other (
 import Cardano.BM.Trace (Trace)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Cache (insertDatumAndCache, queryDatum, queryMAWithCache, queryOrInsertRewardAccount, queryOrInsertStakeAddress)
-import Cardano.DbSync.Cache.Types (Cache (..), CacheNew (..))
+import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Shelley.Query (queryStakeRefPtr)
 import Cardano.DbSync.Era.Universal.Insert.Grouped
@@ -104,7 +104,7 @@ insertRedeemerData tracer txId txd = do
 insertDatum ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   DB.TxId ->
   Generic.PlutusData ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) DB.DatumId
@@ -126,7 +126,7 @@ insertDatum tracer cache txId txd = do
 insertWithdrawals ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   DB.TxId ->
   Map Word64 DB.RedeemerId ->
   Generic.TxWithdrawal ->
@@ -147,7 +147,7 @@ insertWithdrawals _tracer cache txId redeemers txWdrl = do
 insertStakeAddressRefIfMissing ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   Ledger.Addr StandardCrypto ->
   ReaderT SqlBackend m (Maybe DB.StakeAddressId)
 insertStakeAddressRefIfMissing _trce cache addr =
@@ -163,7 +163,7 @@ insertStakeAddressRefIfMissing _trce cache addr =
 
 insertMultiAsset ::
   (MonadBaseControl IO m, MonadIO m) =>
-  Cache ->
+  CacheStatus ->
   PolicyID StandardCrypto ->
   AssetName ->
   ReaderT SqlBackend m DB.MultiAssetId

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
@@ -21,7 +21,7 @@ module Cardano.DbSync.Era.Universal.Insert.Other (
 import Cardano.BM.Trace (Trace)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Cache (insertDatumAndCache, queryDatum, queryMAWithCache, queryOrInsertRewardAccount, queryOrInsertStakeAddress)
-import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..))
+import Cardano.DbSync.Cache.Types (CacheStatus (..), CacheUpdateAction (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Shelley.Query (queryStakeRefPtr)
 import Cardano.DbSync.Era.Universal.Insert.Grouped
@@ -133,7 +133,7 @@ insertWithdrawals ::
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertWithdrawals _tracer cache txId redeemers txWdrl = do
   addrId <-
-    lift $ queryOrInsertRewardAccount cache CacheNew $ Generic.txwRewardAccount txWdrl
+    lift $ queryOrInsertRewardAccount cache UpdateCache $ Generic.txwRewardAccount txWdrl
   void . lift . DB.insertWithdrawal $
     DB.Withdrawal
       { DB.withdrawalAddrId = addrId
@@ -150,13 +150,13 @@ insertStakeAddressRefIfMissing ::
   CacheStatus ->
   Ledger.Addr StandardCrypto ->
   ReaderT SqlBackend m (Maybe DB.StakeAddressId)
-insertStakeAddressRefIfMissing _trce cache addr =
+insertStakeAddressRefIfMissing _trce cacheStatus addr =
   case addr of
     Ledger.AddrBootstrap {} -> pure Nothing
     Ledger.Addr nw _pcred sref ->
       case sref of
         Ledger.StakeRefBase cred -> do
-          Just <$> queryOrInsertStakeAddress cache DontCacheNew nw cred
+          Just <$> queryOrInsertStakeAddress cacheStatus DoNotUpdateCache nw cred
         Ledger.StakeRefPtr ptr -> do
           queryStakeRefPtr ptr
         Ledger.StakeRefNull -> pure Nothing

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Pool.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Pool.hs
@@ -26,7 +26,7 @@ import Cardano.DbSync.Cache (
   queryOrInsertStakeAddress,
   queryPoolKeyOrInsert,
  )
-import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..))
+import Cardano.DbSync.Cache.Types (CacheStatus (..), CacheUpdateAction (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Shelley.Query
 import Cardano.DbSync.Error
@@ -60,8 +60,8 @@ insertPoolRegister ::
   Word16 ->
   PoolP.PoolParams StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
-insertPoolRegister _tracer cache isMember mdeposits network (EpochNo epoch) blkId txId idx params = do
-  poolHashId <- lift $ insertPoolKeyWithCache cache CacheNew (PoolP.ppId params)
+insertPoolRegister _tracer cacheStatus isMember mdeposits network (EpochNo epoch) blkId txId idx params = do
+  poolHashId <- lift $ insertPoolKeyWithCache cacheStatus UpdateCache (PoolP.ppId params)
   mdId <- case strictMaybeToMaybe $ PoolP.ppMetadata params of
     Just md -> Just <$> insertPoolMetaDataRef poolHashId txId md
     Nothing -> pure Nothing
@@ -70,7 +70,7 @@ insertPoolRegister _tracer cache isMember mdeposits network (EpochNo epoch) blkI
   let epochActivationDelay = if isRegistration then 2 else 3
       deposit = if isRegistration then Generic.coinToDbLovelace . Generic.poolDeposit <$> mdeposits else Nothing
 
-  saId <- lift $ queryOrInsertRewardAccount cache CacheNew (adjustNetworkTag $ PoolP.ppRewardAccount params)
+  saId <- lift $ queryOrInsertRewardAccount cacheStatus UpdateCache (adjustNetworkTag $ PoolP.ppRewardAccount params)
   poolUpdateId <-
     lift
       . DB.insertPoolUpdate
@@ -88,7 +88,7 @@ insertPoolRegister _tracer cache isMember mdeposits network (EpochNo epoch) blkI
         , DB.poolUpdateRegisteredTxId = txId
         }
 
-  mapM_ (insertPoolOwner cache network poolUpdateId) $ toList (PoolP.ppOwners params)
+  mapM_ (insertPoolOwner cacheStatus network poolUpdateId) $ toList (PoolP.ppOwners params)
   mapM_ (insertPoolRelay poolUpdateId) $ toList (PoolP.ppRelays params)
   where
     isPoolRegistration :: MonadIO m => DB.PoolHashId -> ExceptT SyncNodeError (ReaderT SqlBackend m) Bool
@@ -116,8 +116,8 @@ insertPoolRetire ::
   Word16 ->
   Ledger.KeyHash 'Ledger.StakePool StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
-insertPoolRetire trce txId cache epochNum idx keyHash = do
-  poolId <- lift $ queryPoolKeyOrInsert "insertPoolRetire" trce cache CacheNew True keyHash
+insertPoolRetire trce txId cacheStatus epochNum idx keyHash = do
+  poolId <- lift $ queryPoolKeyOrInsert "insertPoolRetire" trce cacheStatus UpdateCache True keyHash
   void . lift . DB.insertPoolRetire $
     DB.PoolRetire
       { DB.poolRetireHashId = poolId
@@ -149,8 +149,8 @@ insertPoolOwner ::
   DB.PoolUpdateId ->
   Ledger.KeyHash 'Ledger.Staking StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
-insertPoolOwner cache network poolUpdateId skh = do
-  saId <- lift $ queryOrInsertStakeAddress cache CacheNew network (Ledger.KeyHashObj skh)
+insertPoolOwner cacheStatus network poolUpdateId skh = do
+  saId <- lift $ queryOrInsertStakeAddress cacheStatus UpdateCache network (Ledger.KeyHashObj skh)
   void . lift . DB.insertPoolOwner $
     DB.PoolOwner
       { DB.poolOwnerAddrId = saId
@@ -208,7 +208,7 @@ insertPoolCert ::
   Word16 ->
   PoolCert StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
-insertPoolCert tracer cache isMember mdeposits network epoch blkId txId idx pCert =
+insertPoolCert tracer cacheStatus isMember mdeposits network epoch blkId txId idx pCert =
   case pCert of
-    RegPool pParams -> insertPoolRegister tracer cache isMember mdeposits network epoch blkId txId idx pParams
-    RetirePool keyHash epochNum -> insertPoolRetire tracer txId cache epochNum idx keyHash
+    RegPool pParams -> insertPoolRegister tracer cacheStatus isMember mdeposits network epoch blkId txId idx pParams
+    RetirePool keyHash epochNum -> insertPoolRetire tracer txId cacheStatus epochNum idx keyHash

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Pool.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Pool.hs
@@ -26,7 +26,7 @@ import Cardano.DbSync.Cache (
   queryOrInsertStakeAddress,
   queryPoolKeyOrInsert,
  )
-import Cardano.DbSync.Cache.Types (Cache (..), CacheNew (..))
+import Cardano.DbSync.Cache.Types (CacheNew (..), CacheStatus (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Shelley.Query
 import Cardano.DbSync.Error
@@ -50,7 +50,7 @@ type IsPoolMember = PoolKeyHash -> Bool
 insertPoolRegister ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   IsPoolMember ->
   Maybe Generic.Deposits ->
   Ledger.Network ->
@@ -111,7 +111,7 @@ insertPoolRetire ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
   DB.TxId ->
-  Cache ->
+  CacheStatus ->
   EpochNo ->
   Word16 ->
   Ledger.KeyHash 'Ledger.StakePool StandardCrypto ->
@@ -144,7 +144,7 @@ insertPoolMetaDataRef poolId txId md =
 
 insertPoolOwner ::
   (MonadBaseControl IO m, MonadIO m) =>
-  Cache ->
+  CacheStatus ->
   Ledger.Network ->
   DB.PoolUpdateId ->
   Ledger.KeyHash 'Ledger.Staking StandardCrypto ->
@@ -198,7 +198,7 @@ insertPoolRelay updateId relay =
 insertPoolCert ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   IsPoolMember ->
   Maybe Generic.Deposits ->
   Ledger.Network ->

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Tx.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Tx.hs
@@ -18,7 +18,7 @@ import Cardano.Db (DbLovelace (..), DbWord64 (..))
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
 import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv (..))
-import Cardano.DbSync.Cache.Types (Cache (..))
+import Cardano.DbSync.Cache.Types (CacheStatus (..))
 
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Shelley.Generic.Metadata (TxMetadataValue (..), metadataValueToJsonNoSchema)
@@ -192,7 +192,7 @@ insertTx syncEnv isMember blkId epochNo slotNo applyResult blockIndex tx grouped
 insertTxOut ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   InsertOptions ->
   (DB.TxId, ByteString) ->
   Generic.TxOut ->
@@ -276,7 +276,7 @@ insertTxMetadata tracer txId inOpts mmetadata = do
 insertMaTxMint ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   DB.TxId ->
   MultiAsset StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) [DB.MaTxMint]
@@ -307,7 +307,7 @@ insertMaTxMint _tracer cache txId (MultiAsset mintMap) =
 insertMaTxOuts ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   Map (PolicyID StandardCrypto) (Map AssetName Integer) ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) [MissingMaTxOut]
 insertMaTxOuts _tracer cache maMap =
@@ -339,7 +339,7 @@ insertMaTxOuts _tracer cache maMap =
 insertCollateralTxOut ::
   (MonadBaseControl IO m, MonadIO m) =>
   Trace IO Text ->
-  Cache ->
+  CacheStatus ->
   InsertOptions ->
   (DB.TxId, ByteString) ->
   Generic.TxOut ->


### PR DESCRIPTION
# Description

Found the type names confusing:
```
data Cache
  = UninitiatedCache
  | Cache !CacheInternal
```
So renamed it to reflect the fact that it acts like a `Maybe`:
```
data CacheStatus
  = NoCache
  | ActiveCache !CacheInternal
```

Also did this type whilst I was at it:
```
data CacheNew
  = CacheNew
  | DontCacheNew
  | EvictAndReturn
```
to
```
data CacheUpdateAction
  = UpdateCache
  | DoNotUpdateCache
  | EvictAndUpdateCache
```