### PR TITLE
Fix: Sancho 5-1-0 followup

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -25,6 +25,11 @@ jobs:
           - os: macos-latest
             compiler-nix-name: ghc96
 
+    env:
+      # Increment this value to "invalidate" the cabal cache. Be sure to do this
+      # after updating dependencies (Hackage or chap)
+      CABAL_CACHE_VERSION: 1
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -48,8 +53,8 @@ jobs:
           path: |
             ~/.cabal-devx/packages
             ~/.cabal-devx/store
-          key: ${{ runner.os }}-${{ matrix.compiler-nix-name }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.compiler-nix-name }}-
+          key: ${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          restore-keys: ${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}-
       - name: cabal update
         run: cabal update
       - name: cabal build dependencies

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -177,6 +177,13 @@ If this fails to build, it may also be necessary to update haskell.nix::
 
   nix flake lock --update-input haskellNix
 
+Increment ``CABAL_CACHE_VERSION`` in ``.github/workflows/haskell.yml``::
+
+  env:
+    # Increment this value to "invalidate" the cabal cache. Be sure to do this
+    # after updating dependencies (Hackage or chap)
+    CABAL_CACHE_VERSION: 2
+
 From the Cardano Haskell Package repository
 -------------------------------------------
 
@@ -214,6 +221,13 @@ If there are updated configuration files, be sure to also update ``iohk-nix``::
 In rare cases, it may also be necessary to update haskell.nix::
 
   nix flake lock --update-input haskellNix
+
+Increment ``CABAL_CACHE_VERSION`` in ``.github/workflows/haskell.yml``::
+
+  env:
+    # Increment this value to "invalidate" the cabal cache. Be sure to do this
+    # after updating dependencies (Hackage or chap)
+    CABAL_CACHE_VERSION: 2
 
 Using unreleased versions of dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/cabal.project
+++ b/cabal.project
@@ -36,6 +36,11 @@ package cardano-db-tool
 package cardano-smash-server
   ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports -Wunused-packages
 
+package cardano-node
+   -- We are using cardano-node as a library and we never use the systemd scribe, so there
+   -- is no benefit to linking against it
+   flags: -systemd
+
 package postgresql-libpq
    flags: +use-pkg-config
 

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo.hs
@@ -69,8 +69,8 @@ unitTests iom knownMigrations =
         , test "2000 delegations" AlzStake.delegations2000
         , test "2001 delegations" AlzStake.delegations2001
         , test "8000 delegations" AlzStake.delegations8000
-        --        , test "many delegations" AlzStake.delegationsMany
-        --        , test "many delegations, sparse chain" AlzStake.delegationsManyNotDense
+        , test "many delegations" AlzStake.delegationsMany
+        , test "many delegations, sparse chain" AlzStake.delegationsManyNotDense
         ]
     , testGroup
         "plutus spend scripts"

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage.hs
@@ -109,8 +109,8 @@ unitTests iom knownMigrations =
         , test "2000 delegations" BabStake.delegations2000
         , test "2001 delegations" BabStake.delegations2001
         , test "8000 delegations" BabStake.delegations8000
-        --        , test "many delegations" BabStake.delegationsMany
-        --        , test "many delegations, sparse chain" BabStake.delegationsManyNotDense
+        , test "many delegations" BabStake.delegationsMany
+        , test "many delegations, sparse chain" BabStake.delegationsManyNotDense
         ]
     , testGroup
         "rewards"

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
@@ -131,8 +131,8 @@ unitTests iom knownMigrations =
         , test "2000 delegations" Stake.delegations2000
         , test "2001 delegations" Stake.delegations2001
         , test "8000 delegations" Stake.delegations8000
-        --        , test "many delegations" Stake.delegationsMany
-        --        , test "many delegations, sparse chain" Stake.delegationsManyNotDense
+        , test "many delegations" Stake.delegationsMany
+        , test "many delegations, sparse chain" Stake.delegationsManyNotDense
         ]
     , testGroup
         "rewards"

--- a/flake.nix
+++ b/flake.nix
@@ -190,9 +190,6 @@
                 packages.katip.doExactConfig = true;
                 # Split data to reduce closure size
                 packages.ekg.components.library.enableSeparateDataOutput = true;
-                # Systemd can't be statically linked
-                packages.cardano-node.flags.systemd =
-                  !pkgs.stdenv.hostPlatform.isMusl;
               })
 
               ({
@@ -248,20 +245,6 @@
                   packages.cardano-chain-gen.components.tests.cardano-chain-gen =
                     postgresTest;
                 })
-
-              ({ lib, pkgs, ... }: {
-                # TODO[sgillespie]: The following line is currently required to avoid
-                # the following error:
-                #
-                #     error: The Haskell package set does not contain the package:
-                #     lobemo-scribe-systemd (build dependency).  If you are using Stackage,
-                #     make sure that you are using a snapshot that contains the
-                #     package. Otherwise you may need to update the Hackage snapshot you are
-                #     using, usually by updating haskell.nix.
-                #
-                # This started happening here: https://github.com/input-output-hk/hackage.nix/commit/958f69d793847b532874a66201a491423f2ec551
-                packages.cardano-node.flags.systemd = lib.mkForce false;
-              })
             ];
           })).appendOverlays [
             # Collect local package `exe`s


### PR DESCRIPTION
# Description

Fixes a handful of "broken windows" that were discovered or worked around for sancho-5-1-0:

 * Re-enable long running tests
 * Disable linking against systemd
 * Add a cache-busting parameter to github workflow

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
