### PR TITLE
Improve stake cache

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -404,7 +404,7 @@ mkSyncEnv trce backend connectionString syncOptions protoInfo nw nwMagic systemS
       then
         newEmptyCache
           LRUCacheCapacity
-            { lirCapacityStakeHashRaw = 1600000
+            { lirCapacityStakeHashRaw = 100000
             , lruCapacityDatum = 250000
             , lruCapacityMultiAsset = 250000
             }

--- a/cardano-db-sync/src/Cardano/DbSync/Cache.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache.hs
@@ -30,7 +30,7 @@ import Cardano.BM.Trace
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Cache.Epoch (rollbackMapEpochInCache)
 import qualified Cardano.DbSync.Cache.LRU as LRU
-import Cardano.DbSync.Cache.Types (CacheAction (..), CacheInternal (..), CacheStatistics (..), CacheStatus (..), initCacheStatistics, isCacheActionUpdate)
+import Cardano.DbSync.Cache.Types (CacheAction (..), CacheInternal (..), CacheStatistics (..), CacheStatus (..), StakeCache (..), initCacheStatistics)
 import qualified Cardano.DbSync.Era.Shelley.Generic.Util as Generic
 import Cardano.DbSync.Era.Shelley.Query
 import Cardano.DbSync.Era.Util
@@ -160,16 +160,16 @@ queryStakeAddrWithCacheRetBs _trce cache cacheUA nw cred = do
     NoCache -> do
       mapLeft (,bs) <$> resolveStakeAddress bs
     ActiveCache ci -> do
-      currentCache <- liftIO $ readTVarIO (cStakeRawHashes ci)
-      case LRU.lookup cred currentCache of
-        Just (addrId, lruCache) -> do
+      stakeCache <- liftIO $ readTVarIO (cStakeRawHashes ci)
+      case queryStakeCache cred stakeCache of
+        Just (addrId, stakeCache', _) -> do
           liftIO $ hitCreds (cStats ci)
           case cacheUA of
             EvictAndUpdateCache -> do
-              liftIO $ atomically $ writeTVar (cStakeRawHashes ci) $ LRU.delete cred lruCache
+              liftIO $ atomically $ writeTVar (cStakeRawHashes ci) $ deleteStakeCache cred stakeCache'
               pure $ Right addrId
             _other -> do
-              liftIO $ atomically $ writeTVar (cStakeRawHashes ci) lruCache
+              liftIO $ atomically $ writeTVar (cStakeRawHashes ci) stakeCache'
               pure $ Right addrId
         Nothing -> do
           queryRes <- mapLeft (,bs) <$> resolveStakeAddress bs
@@ -177,12 +177,26 @@ queryStakeAddrWithCacheRetBs _trce cache cacheUA nw cred = do
           case queryRes of
             Left _ -> pure queryRes
             Right stakeAddrsId -> do
-              when (isCacheActionUpdate cacheUA) $
-                liftIO $
-                  atomically $
-                    modifyTVar (cStakeRawHashes ci) $
-                      LRU.insert cred stakeAddrsId
+              let !stakeCache' = case cacheUA of
+                    UpdateCache -> stakeCache {scLruCache = LRU.insert cred stakeAddrsId (scLruCache stakeCache)}
+                    UpdateCacheStrong -> stakeCache {scStableCache = Map.insert cred stakeAddrsId (scStableCache stakeCache)}
+                    _ -> stakeCache
+              liftIO $
+                atomically $
+                  writeTVar (cStakeRawHashes ci) stakeCache'
               pure $ Right stakeAddrsId
+
+-- | True if it was found in LRU
+queryStakeCache :: StakeCred -> StakeCache -> Maybe (DB.StakeAddressId, StakeCache, Bool)
+queryStakeCache scred scache = case Map.lookup scred (scStableCache scache) of
+  Just addrId -> Just (addrId, scache, False)
+  Nothing -> case LRU.lookup scred (scLruCache scache) of
+    Just (addrId, lru') -> Just (addrId, scache {scLruCache = lru'}, True)
+    Nothing -> Nothing
+
+deleteStakeCache :: StakeCred -> StakeCache -> StakeCache
+deleteStakeCache scred scache =
+  scache {scStableCache = Map.delete scred (scStableCache scache)}
 
 queryPoolKeyWithCache ::
   MonadIO m =>

--- a/cardano-db-sync/src/Cardano/DbSync/Cache.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache.hs
@@ -154,31 +154,19 @@ queryStakeAddrWithCacheRetBs ::
   Network ->
   StakeCred ->
   ReaderT SqlBackend m (Either (DB.LookupFail, ByteString) DB.StakeAddressId)
-queryStakeAddrWithCacheRetBs trce cache cacheUA nw cred = do
-  let !bs = Ledger.serialiseRewardAccount (Ledger.RewardAccount nw cred)
+queryStakeAddrWithCacheRetBs _trce cache cacheUA nw cred = do
+  let bs = Ledger.serialiseRewardAccount (Ledger.RewardAccount nw cred)
   case cache of
     NoCache -> do
       mapLeft (,bs) <$> resolveStakeAddress bs
     ActiveCache ci -> do
-      prevCache <- liftIO $ readTVarIO (cStakeRawHashes ci)
-      let isNewCache = LRU.getSize prevCache < 1
-      -- populate from db if the cache is empty
-      currentCache <-
-        if isNewCache
-          then do
-            liftIO $ logInfo trce "Stake Raw Hashes cache is new and empty. Populating with addresses from db..."
-            queryRes <- DB.queryAddressWithReward (fromIntegral $ LRU.getCapacity prevCache)
-            liftIO $ atomically $ writeTVar (cStakeRawHashes ci) $ LRU.fromList queryRes prevCache
-            liftIO $ logInfo trce "Population of cache complete."
-            liftIO $ readTVarIO (cStakeRawHashes ci)
-          else pure prevCache
-
-      case LRU.lookup bs currentCache of
+      currentCache <- liftIO $ readTVarIO (cStakeRawHashes ci)
+      case LRU.lookup cred currentCache of
         Just (addrId, lruCache) -> do
           liftIO $ hitCreds (cStats ci)
           case cacheUA of
             EvictAndUpdateCache -> do
-              liftIO $ atomically $ writeTVar (cStakeRawHashes ci) $ LRU.delete bs lruCache
+              liftIO $ atomically $ writeTVar (cStakeRawHashes ci) $ LRU.delete cred lruCache
               pure $ Right addrId
             _other -> do
               liftIO $ atomically $ writeTVar (cStakeRawHashes ci) lruCache
@@ -193,7 +181,7 @@ queryStakeAddrWithCacheRetBs trce cache cacheUA nw cred = do
                 liftIO $
                   atomically $
                     modifyTVar (cStakeRawHashes ci) $
-                      LRU.insert bs stakeAddrsId
+                      LRU.insert cred stakeAddrsId
               pure $ Right stakeAddrsId
 
 queryPoolKeyWithCache ::

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -19,6 +20,9 @@ module Cardano.DbSync.Cache.Types (
   useNoCache,
   initCacheStatistics,
   newEmptyCache,
+
+  -- * Utils
+  shouldCache,
 
   -- * CacheStatistics
   CacheStatistics (..),
@@ -190,3 +194,9 @@ initCacheStatistics = CacheStatistics 0 0 0 0 0 0 0 0 0 0
 
 initCacheEpoch :: CacheEpoch
 initCacheEpoch = CacheEpoch mempty Nothing
+
+shouldCache :: CacheAction -> Bool
+shouldCache = \case
+  UpdateCache -> True
+  UpdateCacheStrong -> True
+  _ -> False

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
@@ -30,7 +30,7 @@ module Cardano.DbSync.Cache.Types (
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Cache.LRU (LRUCache)
 import qualified Cardano.DbSync.Cache.LRU as LRU
-import Cardano.DbSync.Types (DataHash, PoolKeyHash)
+import Cardano.DbSync.Types (DataHash, PoolKeyHash, StakeCred)
 import Cardano.Ledger.Mary.Value (AssetName, PolicyID)
 import Cardano.Prelude
 import Control.Concurrent.Class.MonadSTM.Strict (
@@ -58,7 +58,7 @@ data CacheAction
   deriving (Eq)
 
 data CacheInternal = CacheInternal
-  { cStakeRawHashes :: !(StrictTVar IO (LRUCache ByteString DB.StakeAddressId))
+  { cStakeRawHashes :: !(StrictTVar IO (LRUCache StakeCred DB.StakeAddressId))
   , cPools :: !(StrictTVar IO StakePoolCache)
   , cDatum :: !(StrictTVar IO (LRUCache DataHash DB.DatumId))
   , cMultiAssets :: !(StrictTVar IO (LRUCache (PolicyID StandardCrypto, AssetName) DB.MultiAssetId))

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Epoch.hs
@@ -214,7 +214,7 @@ insertEpochStake syncEnv nw epochNo stakeChunk = do
       (StakeCred, (Shelley.Coin, PoolKeyHash)) ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) DB.EpochStake
     mkStake cache (saddr, (coin, pool)) = do
-      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCache nw saddr
+      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCacheStrong nw saddr
       poolId <- lift $ queryPoolKeyOrInsert "insertEpochStake" trce cache UpdateCache (ioShelley iopts) pool
       pure $
         DB.EpochStake
@@ -248,7 +248,7 @@ insertRewards syncEnv nw earnedEpoch spendableEpoch cache rewardsChunk = do
       (StakeCred, Set Generic.Reward) ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) [DB.Reward]
     mkRewards (saddr, rset) = do
-      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCache nw saddr
+      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCacheStrong nw saddr
       mapM (prepareReward saId) (Set.toList rset)
 
     prepareReward ::
@@ -298,7 +298,7 @@ insertRewardRests trce nw earnedEpoch spendableEpoch cache rewardsChunk = do
       (StakeCred, Set Generic.RewardRest) ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) [DB.RewardRest]
     mkRewards (saddr, rset) = do
-      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCache nw saddr
+      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCacheStrong nw saddr
       pure $ map (prepareReward saId) (Set.toList rset)
 
     prepareReward ::
@@ -332,7 +332,7 @@ insertProposalRefunds trce nw earnedEpoch spendableEpoch cache refunds = do
       GovActionRefunded ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) DB.RewardRest
     mkReward refund = do
-      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCache nw (raCredential $ garReturnAddr refund)
+      saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCacheStrong nw (raCredential $ garReturnAddr refund)
       pure $
         DB.RewardRest
           { DB.rewardRestAddrId = saId

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Certificate.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Certificate.hs
@@ -193,7 +193,7 @@ insertMirCert tracer cache network txId idx mcert = do
       (StakeCred, Ledger.DeltaCoin) ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) ()
     insertMirReserves (cred, dcoin) = do
-      addrId <- lift $ queryOrInsertStakeAddress tracer cache UpdateCache network cred
+      addrId <- lift $ queryOrInsertStakeAddress tracer cache UpdateCacheStrong network cred
       void . lift . DB.insertReserve $
         DB.Reserve
           { DB.reserveAddrId = addrId
@@ -207,7 +207,7 @@ insertMirCert tracer cache network txId idx mcert = do
       (StakeCred, Ledger.DeltaCoin) ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) ()
     insertMirTreasury (cred, dcoin) = do
-      addrId <- lift $ queryOrInsertStakeAddress tracer cache UpdateCache network cred
+      addrId <- lift $ queryOrInsertStakeAddress tracer cache UpdateCacheStrong network cred
       void . lift . DB.insertTreasury $
         DB.Treasury
           { DB.treasuryAddrId = addrId
@@ -413,7 +413,7 @@ insertDelegation ::
   Ledger.KeyHash 'Ledger.StakePool StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertDelegation trce cache network (EpochNo epoch) slotNo txId idx mRedeemerId cred poolkh = do
-  addrId <- lift $ queryOrInsertStakeAddress trce cache UpdateCache network cred
+  addrId <- lift $ queryOrInsertStakeAddress trce cache UpdateCacheStrong network cred
   poolHashId <- lift $ queryPoolKeyOrInsert "insertDelegation" trce cache UpdateCache True poolkh
   void . lift . DB.insertDelegation $
     DB.Delegation
@@ -437,7 +437,7 @@ insertDelegationVote ::
   DRep StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertDelegationVote trce cache network txId idx cred drep = do
-  addrId <- lift $ queryOrInsertStakeAddress trce cache UpdateCache network cred
+  addrId <- lift $ queryOrInsertStakeAddress trce cache UpdateCacheStrong network cred
   drepId <- lift $ insertDrep drep
   void
     . lift

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
@@ -155,7 +155,7 @@ insertStakeAddressRefIfMissing trce cache addr =
     Ledger.Addr nw _pcred sref ->
       case sref of
         Ledger.StakeRefBase cred -> do
-          Just <$> queryOrInsertStakeAddress trce cache DoNotUpdateCache nw cred
+          Just <$> queryOrInsertStakeAddress trce cache UpdateCache nw cred
         Ledger.StakeRefPtr ptr -> do
           DB.queryStakeRefPtr ptr
         Ledger.StakeRefNull -> pure Nothing

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Pool.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Pool.hs
@@ -150,7 +150,7 @@ insertPoolOwner ::
   Ledger.KeyHash 'Ledger.Staking StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertPoolOwner trce cache network poolUpdateId skh = do
-  saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCache network (Ledger.KeyHashObj skh)
+  saId <- lift $ queryOrInsertStakeAddress trce cache UpdateCacheStrong network (Ledger.KeyHashObj skh)
   void . lift . DB.insertPoolOwner $
     DB.PoolOwner
       { DB.poolOwnerAddrId = saId

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,6 +1,5 @@
 # Schema Documentation for cardano-db-sync
 
-Schema version: 13.2.0.2
 **Note:** This file is auto-generated from the documentation in cardano-db/src/Cardano/Db/Schema.hs by the command `cabal run -- gen-schema-docs doc/schema.md`. This document should only be updated during the release process and updated on the release branch.
 
 ### `schema_version`
@@ -86,6 +85,18 @@ A table for transactions within a block on the chain.
 | `invalid_hereafter` | word64type | Transaction in invalid at or after this slot number. |
 | `valid_contract` | boolean | False if the contract is invalid. True if the contract is valid or there is no contract. |
 | `script_size` | word31type | The sum of the script sizes (in bytes) of scripts in the transaction. |
+
+### `tx_cbor`
+
+A table holding raw CBOR encoded transactions.
+
+* Primary Id: `id`
+
+| Column name | Type | Description |
+|-|-|-|
+| `id` | integer (64) |  |
+| `tx_id` | integer (64) | The Tx table index of the transaction encoded in this table. |
+| `bytes` | bytea | CBOR encoded transaction. |
 
 ### `reverse_index`
 
@@ -789,7 +800,7 @@ A table for every unique drep key hash. The existance of an entry doesn't mean t
 
 ### `committee_hash`
 
-A table for all committee hot credentials
+A table for all committee credentials hot or cold
 
 * Primary Id: `id`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         max-file: "10"
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:8.9.3
+    image: ghcr.io/intersectmbo/cardano-node:8.12.2
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -53,7 +53,7 @@ services:
         max-file: "10"
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.2.0.2
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.3.0.0
     environment:
       - DISABLE_LEDGER=${DISABLE_LEDGER}
       - NETWORK=${NETWORK:-mainnet}

--- a/schema/migration-2-0034-20240301.sql
+++ b/schema/migration-2-0034-20240301.sql
@@ -8,8 +8,10 @@ BEGIN
   IF next_version = 34 THEN
     EXECUTE 'ALTER TABLE "param_proposal" ADD COLUMN "pvtpp_security_group" DOUBLE PRECISION NULL' ;
     EXECUTE 'ALTER TABLE "epoch_param" ADD COLUMN "pvtpp_security_group" DOUBLE PRECISION NULL' ;
-    EXECUTE 'ALTER TABLE "pool_update" ADD COLUMN "deposit" lovelace NULL' ;
-    EXECUTE 'ALTER TABLE "stake_registration" ADD COLUMN "deposit" lovelace NULL' ;
+    EXECUTE 'ALTER TABLE "pool_update" ADD COLUMN "deposit" lovelace NULL DEFAULT 500000000' ;
+    EXECUTE 'ALTER TABLE "pool_update" ALTER COLUMN "deposit" DROP DEFAULT' ;
+    EXECUTE 'ALTER TABLE "stake_registration" ADD COLUMN "deposit" lovelace NULL DEFAULT 2000000' ;
+    EXECUTE 'ALTER TABLE "stake_registration" ALTER COLUMN "deposit" DROP DEFAULT' ;
     EXECUTE 'ALTER TABLE "ada_pots" RENAME COLUMN "deposits" TO "deposits_stake"';
     EXECUTE 'ALTER TABLE "ada_pots" ADD COLUMN "deposits_drep" lovelace NOT NULL DEFAULT 0' ;
     EXECUTE 'ALTER TABLE "ada_pots" ADD COLUMN "deposits_proposal" lovelace NOT NULL DEFAULT 0';


### PR DESCRIPTION
# Description

Use ledger types instead of ByteString and use double cache.
- One cache works as before: it's only populated for addresses with rewards/delegations and entries are only evicted manually on a deregistration. Exptected current size on mainnet os 1_700_000
- A second smaller LRU cache with capacity 100_000.
 
# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
