### PR TITLE
Fix: Remove "Just" prefix in error messages for OffChainFetchError

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Types.hs
@@ -241,7 +241,7 @@ instance Show OffChainFetchError where
       OCFErrHashMismatch url xpt act ->
         mconcat
           [ "Hash mismatch when fetching metadata from "
-          , show url
+          , showMUrl url
           , ". Expected "
           , show xpt
           , " but got "
@@ -256,7 +256,7 @@ instance Show OffChainFetchError where
           [fetchUrlToString url, "URL parse error for ", show url, " resulted in : ", show err]
       OCFErrJsonDecodeFail url err ->
         mconcat
-          [fetchMUtlToString url, "JSON decode error from when fetching metadata from ", show url, " resulted in : ", show err]
+          [fetchMUrlToString url, "JSON decode error from when fetching metadata from ", show url, " resulted in : ", show err]
       OCFErrHttpException url err ->
         mconcat [fetchUrlToString url, "HTTP Exception error for ", show url, " resulted in : ", show err]
       OCFErrHttpResponse url sc msg ->
@@ -269,11 +269,16 @@ instance Show OffChainFetchError where
         mconcat [fetchUrlToString url, "Timeout error when fetching metadata from ", show url, ": ", show ctx]
       OCFErrConnectionFailure url ->
         mconcat
-          [fetchUrlToString url, "Connection failure error when fetching metadata from ", show url, "'."]
+          [fetchUrlToString url, "Connection failure error when fetching metadata from ", show url, "."]
       OCFErrIOException err -> "IO Exception: " <> show err
 
-fetchMUtlToString :: Maybe OffChainUrlType -> String
-fetchMUtlToString = \case
+showMUrl :: Maybe OffChainUrlType -> String
+showMUrl = \case
+  Nothing -> "unknown URL"
+  Just url -> show url
+
+fetchMUrlToString :: Maybe OffChainUrlType -> String
+fetchMUrlToString = \case
   Nothing -> ""
   Just url -> fetchUrlToString url
 


### PR DESCRIPTION
- Updated the `Show` instance for `OffChainFetchError` to use a custom function that properly formats `Maybe OffChainUrlType` values.
- Added `showMaybeUrl` helper function to convert `Maybe OffChainUrlType` to string without including "Just".
- Remove redundant single quote from connection failure string.


Before:

```sql
preprod_5_1_0=# select * from off_chain_pool_fetch_error LIMIT 5;
 id | pool_id |         fetch_time         | pmr_id |                                                                                                                            fetch_error                                                                                                                             | retry_count 
----+---------+----------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------
  1 |      14 | 2024-07-04 11:12:34.039445 |     11 | Hash mismatch when fetching metadata from Just https://xstakepool.com/testnet-xstakepool.json. Expected "25d14c92cd852bbe666858ba040db7d5dd0767838e604e16c12b8fb842cf89ec" but got "d5d8f5f5b1edc2caea1e44618c5b05256336795c39a7a4dd7032cf15ecccda39".             |           0
  2 |      15 | 2024-07-04 11:12:34.039445 |    111 | Error Offchain Pool: Connection failure error when fetching metadata from https://api.monrma.ml/meta/PILDR.json'.                                                                                                                                                  |           0
  3 |      16 | 2024-07-04 11:12:34.039445 |     14 | Error Offchain Pool: Connection failure error when fetching metadata from https://adamute.com/paltz/poolmeta.json'.                                                                                                                                                |           0
  4 |      17 | 2024-07-04 11:12:34.039445 |     84 | Hash mismatch when fetching metadata from Just https://adacapital.io/adact_preprod.json. Expected "ac5fbc53a3d1493b5ba0ea1772fd5d4fda3cd72ba89503ff2261a39052fcd2f5" but got "276d922714a748c5c47afa3ec17170bee9da6db4b7e3b1373dfc982b97babc90".                   |           0
  5 |      27 | 2024-07-04 11:12:34.039445 |     25 | Hash mismatch when fetching metadata from Just https://gitlab.com/santiagopim/spo/-/raw/master/SP002.json. Expected "cec0f467a80e65b9482e7a7a05db8ad15713d4439cadbab96b7f3285fab54916" but got "cf2941d06c30d4f2abec9ac9877021da98bc3a64eb6ba2b2e818eb02e5712e16". |           0
(5 rows)
```

After:

```sql
my_preprod_5_1_0=# select * from off_chain_pool_fetch_error LIMIT 5;
 id | pool_id |         fetch_time         | pmr_id |                                                                                                                          fetch_error                                                                                                                          | retry_count 
----+---------+----------------------------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------
  1 |      14 | 2024-07-06 13:17:26.780741 |     11 | Hash mismatch when fetching metadata from https://xstakepool.com/testnet-xstakepool.json. Expected "25d14c92cd852bbe666858ba040db7d5dd0767838e604e16c12b8fb842cf89ec" but got "d5d8f5f5b1edc2caea1e44618c5b05256336795c39a7a4dd7032cf15ecccda39".             |           0
  2 |      15 | 2024-07-06 13:17:26.780741 |    111 | Error Offchain Pool: Connection failure error when fetching metadata from https://api.monrma.ml/meta/PILDR.json.                                                                                                                                              |           0
  3 |      16 | 2024-07-06 13:17:26.780741 |     14 | Error Offchain Pool: Connection failure error when fetching metadata from https://adamute.com/paltz/poolmeta.json.                                                                                                                                            |           0
  4 |      17 | 2024-07-06 13:17:26.780741 |     84 | Hash mismatch when fetching metadata from https://adacapital.io/adact_preprod.json. Expected "ac5fbc53a3d1493b5ba0ea1772fd5d4fda3cd72ba89503ff2261a39052fcd2f5" but got "276d922714a748c5c47afa3ec17170bee9da6db4b7e3b1373dfc982b97babc90".                   |           0
  5 |      27 | 2024-07-06 13:17:26.780741 |     25 | Hash mismatch when fetching metadata from https://gitlab.com/santiagopim/spo/-/raw/master/SP002.json. Expected "cec0f467a80e65b9482e7a7a05db8ad15713d4439cadbab96b7f3285fab54916" but got "cf2941d06c30d4f2abec9ac9877021da98bc3a64eb6ba2b2e818eb02e5712e16". |           0
(5 rows)
```



# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
