### PR TITLE
Fix: Bump HLS@2.9.0.0 (for ghc96)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -168,7 +168,7 @@
                   if config.compiler-nix-name == "ghc8107" then
                     nixpkgs.haskell-nix.sources."hls-1.10"
                   else
-                    nixpkgs.haskell-nix.sources."hls-2.7";
+                    nixpkgs.haskell-nix.sources."hls-2.9";
               };
             };
             # Now we use pkgsBuildBuild, to make sure that even in the cross


### PR DESCRIPTION
# Description

Should fix compilation errors for HLS:

```
[48 of 76] Compiling Development.IDE.Session ( session-loader/Development/IDE/Session.hs, dist/build/Development/IDE/Session.o, dist/build/Development/IDE/Session.dyn_o )

session-loader/Development/IDE/Session.hs:829:24: error: [GHC-83865]
    • Couldn't match expected type: OS.Set UnitId
                                    -> [(UnitId, UnitId)] -> [Compat.Messages DriverMessage]
                  with actual type: [DriverMessages]
```

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
