### PR TITLE
1641 - config can override presets

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -9,10 +9,6 @@
 
 module Cardano.DbSync.Api (
   extractInsertOptions,
-  fullInsertOptions,
-  onlyUTxOInsertOptions,
-  onlyGovInsertOptions,
-  disableAllInsertOptions,
   setConsistentLevel,
   getConsistentLevel,
   isConsistent,
@@ -211,74 +207,7 @@ getPrunes = do
   DB.pcmPruneTxOut . getPruneConsume
 
 extractInsertOptions :: SyncPreConfig -> SyncInsertOptions
-extractInsertOptions cfg =
-  case pcInsertConfig cfg of
-    FullInsertOptions -> fullInsertOptions
-    OnlyUTxOInsertOptions -> onlyUTxOInsertOptions
-    OnlyGovInsertOptions -> onlyGovInsertOptions
-    DisableAllInsertOptions -> disableAllInsertOptions
-    SyncInsertConfig opts -> opts
-
-fullInsertOptions :: SyncInsertOptions
-fullInsertOptions =
-  SyncInsertOptions
-    { sioTxCBOR = TxCBORConfig False
-    , sioTxOut = TxOutEnable
-    , sioLedger = LedgerEnable
-    , sioShelley = ShelleyEnable
-    , sioRewards = RewardsConfig True
-    , sioMultiAsset = MultiAssetEnable
-    , sioMetadata = MetadataEnable
-    , sioPlutus = PlutusEnable
-    , sioGovernance = GovernanceConfig True
-    , sioOffchainPoolData = OffchainPoolDataConfig True
-    , sioPoolStats = PoolStatsConfig True
-    , sioJsonType = JsonTypeText
-    , sioRemoveJsonbFromSchema = RemoveJsonbFromSchemaConfig False
-    }
-
-onlyUTxOInsertOptions :: SyncInsertOptions
-onlyUTxOInsertOptions =
-  SyncInsertOptions
-    { sioTxCBOR = TxCBORConfig False
-    , sioTxOut = TxOutBootstrap (ForceTxIn False)
-    , sioLedger = LedgerIgnore
-    , sioShelley = ShelleyDisable
-    , sioRewards = RewardsConfig True
-    , sioMultiAsset = MultiAssetDisable
-    , sioMetadata = MetadataDisable
-    , sioPlutus = PlutusDisable
-    , sioGovernance = GovernanceConfig False
-    , sioOffchainPoolData = OffchainPoolDataConfig False
-    , sioPoolStats = PoolStatsConfig False
-    , sioJsonType = JsonTypeText
-    , sioRemoveJsonbFromSchema = RemoveJsonbFromSchemaConfig False
-    }
-
-onlyGovInsertOptions :: SyncInsertOptions
-onlyGovInsertOptions =
-  disableAllInsertOptions
-    { sioLedger = LedgerEnable
-    , sioGovernance = GovernanceConfig True
-    }
-
-disableAllInsertOptions :: SyncInsertOptions
-disableAllInsertOptions =
-  SyncInsertOptions
-    { sioTxCBOR = TxCBORConfig False
-    , sioTxOut = TxOutDisable
-    , sioLedger = LedgerDisable
-    , sioShelley = ShelleyDisable
-    , sioRewards = RewardsConfig False
-    , sioMultiAsset = MultiAssetDisable
-    , sioMetadata = MetadataDisable
-    , sioPlutus = PlutusDisable
-    , sioOffchainPoolData = OffchainPoolDataConfig False
-    , sioPoolStats = PoolStatsConfig False
-    , sioGovernance = GovernanceConfig False
-    , sioJsonType = JsonTypeText
-    , sioRemoveJsonbFromSchema = RemoveJsonbFromSchemaConfig False
-    }
+extractInsertOptions = sicOptions . pcInsertConfig
 
 initCurrentEpochNo :: CurrentEpochNo
 initCurrentEpochNo =

--- a/cardano-db-sync/test/Cardano/DbSync/Config/TypesTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/Config/TypesTest.hs
@@ -47,10 +47,10 @@ prop_syncInsertConfigRoundtrip = property $ do
         SyncInsertConfig Nothing _ -> True
         _other -> False
 
-  cover 5 "full" (isPreset "full")
-  cover 5 "only utxo" (isPreset "only_utxo")
-  cover 5 "only gov" (isPreset "only_gov")
-  cover 5 "disable all" (isPreset "disable_all")
+  cover 5 "full" (isPreset FullInsertPreset)
+  cover 5 "only utxo" (isPreset OnlyUTxOInsertPreset)
+  cover 5 "only gov" (isPreset OnlyGovInsertPreset)
+  cover 5 "disable all" (isPreset DisableAllInsertPreset)
   cover 5 "custom config" isCustomConfig
 
   tripping cfg Aeson.encode Aeson.decode

--- a/cardano-db-sync/test/Cardano/DbSync/Config/TypesTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/Config/TypesTest.hs
@@ -39,16 +39,19 @@ prop_syncInsertConfigRoundtrip :: Property
 prop_syncInsertConfigRoundtrip = property $ do
   cfg <- forAll Gen.syncInsertConfig
 
-  let isSyncInsertConfig =
-        case cfg of
-          SyncInsertConfig _ -> True
-          _ -> False
+  let isPreset preset = case cfg of
+        SyncInsertConfig (Just p) _ -> p == preset
+        _other -> False
 
-  cover 5 "full" (cfg == FullInsertOptions)
-  cover 5 "only utxo" (cfg == OnlyUTxOInsertOptions)
-  cover 5 "only gov" (cfg == OnlyGovInsertOptions)
-  cover 5 "disable all" (cfg == DisableAllInsertOptions)
-  cover 5 "config" isSyncInsertConfig
+  let isCustomConfig = case cfg of
+        SyncInsertConfig Nothing _ -> True
+        _other -> False
+
+  cover 5 "full" (isPreset "full")
+  cover 5 "only utxo" (isPreset "only_utxo")
+  cover 5 "only gov" (isPreset "only_gov")
+  cover 5 "disable all" (isPreset "disable_all")
+  cover 5 "custom config" isCustomConfig
 
   tripping cfg Aeson.encode Aeson.decode
 

--- a/cardano-db-sync/test/Cardano/DbSync/Gen.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/Gen.hs
@@ -107,10 +107,10 @@ syncNodeConfig loggingCfg =
 syncInsertConfig :: Gen SyncInsertConfig
 syncInsertConfig =
   Gen.choice
-    [ pure $ SyncInsertConfig (Just "full") fullInsertOptions
-    , pure $ SyncInsertConfig (Just "only_utxo") onlyUTxOInsertOptions
-    , pure $ SyncInsertConfig (Just "only_gov") onlyGovInsertOptions
-    , pure $ SyncInsertConfig (Just "disable_all") disableAllInsertOptions
+    [ pure $ SyncInsertConfig (Just FullInsertPreset) fullInsertOptions
+    , pure $ SyncInsertConfig (Just OnlyUTxOInsertPreset) onlyUTxOInsertOptions
+    , pure $ SyncInsertConfig (Just OnlyGovInsertPreset) onlyGovInsertOptions
+    , pure $ SyncInsertConfig (Just DisableAllInsertPreset) disableAllInsertOptions
     , SyncInsertConfig Nothing <$> syncInsertOptions
     ]
 

--- a/cardano-db-sync/test/Cardano/DbSync/Gen.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -106,11 +107,11 @@ syncNodeConfig loggingCfg =
 syncInsertConfig :: Gen SyncInsertConfig
 syncInsertConfig =
   Gen.choice
-    [ pure FullInsertOptions
-    , pure OnlyUTxOInsertOptions
-    , pure OnlyGovInsertOptions
-    , pure DisableAllInsertOptions
-    , SyncInsertConfig <$> syncInsertOptions
+    [ pure $ SyncInsertConfig (Just "full") fullInsertOptions
+    , pure $ SyncInsertConfig (Just "only_utxo") onlyUTxOInsertOptions
+    , pure $ SyncInsertConfig (Just "only_gov") onlyGovInsertOptions
+    , pure $ SyncInsertConfig (Just "disable_all") disableAllInsertOptions
+    , SyncInsertConfig Nothing <$> syncInsertOptions
     ]
 
 syncInsertOptions :: Gen SyncInsertOptions


### PR DESCRIPTION
# Description

This fixes #1641

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
