### PR TITLE
Add ENV variable handler to provide custom configuration to Cardano DB Sync

### DIFF
--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -217,7 +217,7 @@ in {
               LEDGER_OPTS="--state-dir ${cfg.stateDir}"
             fi
 
-            if [[ -z "''${CARDANO_DB_SYNC_CONFIG:-}" ]]; then
+            if [[ -z "''${DB_SYNC_CONFIG:-}" ]]; then
               exec ${exec} \
                   --config ${configFile} \
                   --socket-path "$CARDANO_NODE_SOCKET_PATH" \
@@ -227,7 +227,7 @@ in {
                   ''${EXTRA_DB_SYNC_ARGS:-}
             else
               exec ${exec} \
-                  --config "$CARDANO_DB_SYNC_CONFIG" \
+                  --config "$DB_SYNC_CONFIG" \
                   --socket-path "$CARDANO_NODE_SOCKET_PATH" \
                   --schema-dir ${self.schema} \
                   ${toString cfg.rtsArgs} \

--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -217,13 +217,23 @@ in {
               LEDGER_OPTS="--state-dir ${cfg.stateDir}"
             fi
 
-            exec ${exec} \
-                --config ${configFile} \
-                --socket-path "$CARDANO_NODE_SOCKET_PATH" \
-                --schema-dir ${self.schema} \
-                ${toString cfg.rtsArgs} \
-                ''${LEDGER_OPTS} \
-                ''${EXTRA_DB_SYNC_ARGS:-}
+            if [[ -z "''${CARDANO_DB_SYNC_CONFIG:-}" ]]; then
+              exec ${exec} \
+                  --config ${configFile} \
+                  --socket-path "$CARDANO_NODE_SOCKET_PATH" \
+                  --schema-dir ${self.schema} \
+                  ${toString cfg.rtsArgs} \
+                  ''${LEDGER_OPTS} \
+                  ''${EXTRA_DB_SYNC_ARGS:-}
+            else
+              exec ${exec} \
+                  --config "$CARDANO_DB_SYNC_CONFIG" \
+                  --socket-path "$CARDANO_NODE_SOCKET_PATH" \
+                  --schema-dir ${self.schema} \
+                  ${toString cfg.rtsArgs} \
+                  ''${LEDGER_OPTS} \
+                  ''${EXTRA_DB_SYNC_ARGS:-}
+            fi
           '';
     in {
       pgpass = builtins.toFile "pgpass" "${cfg.postgres.socketdir}:${


### PR DESCRIPTION
# Description

Because of [this issue](https://github.com/IntersectMBO/cardano-db-sync/issues/1777#issuecomment-2238847226) the GovTool team is forced to use some custom configuration file (Cardano DB Sync docker image is not provided with required flag enabled)

In order to do that I was in need to change the entrypoint of the DBSync docker image: The current one [hardcodes the configuration](https://github.com/IntersectMBO/cardano-db-sync/blob/master/nix/nixos/cardano-db-sync-service.nix#L221), so it is not adjustable.

This PR introduces a new environment variable, DB_SYNC_CONFIG, allowing users to specify a custom configuration file for the Cardano DB Sync service. The modification in `nix/nixos/cardano-db-sync-service.nix` adds a conditional check to use the custom configuration file if the environment variable is set, providing more flexibility in deployment scenarios and facilitating custom configurations without altering the base code. This change addresses a need for dynamic configuration management as specified in the recent user requirements.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
