### PR TITLE
Fixes for 13.3.0.0

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Fix/PlutusDataBytes.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Fix/PlutusDataBytes.hs
@@ -197,7 +197,7 @@ findWrongPlutusData tracer tableName qCount qPage qGetInfo getHash getBytes hash
 
     checkValidBytes :: a -> m Bool
     checkValidBytes a = case hashBytes a of
-      Left Nothing -> pure True
+      Left Nothing -> pure False
       Left (Just msg) -> do
         liftIO $
           logWarning tracer $

--- a/cardano-db-tool/cardano-db-tool.cabal
+++ b/cardano-db-tool/cardano-db-tool.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db-tool
-version:                13.2.0.2
+version:                13.3.0.1
 synopsis:               Utilities to manage the cardano-db-sync databases.
 description:            Utilities and executable, used to manage and validate the
                         PostgreSQL db and the ledger database of the cardano-db-sync node


### PR DESCRIPTION
# Description

Fixes
- an issue where script data were considered wrong even if they are not
- falling back to CIP-100 if CIP-108 or CIP-119 is not followed
- cardano-db-tool upgrade

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
