### PR TITLE
Docker: Add DB_SYNC_CONFIG to docker compose file

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -66,6 +66,30 @@ To connect to different network (preprod or preview) use `NETWORK` environment v
 NETWORK=preprod docker-compose up -d && docker-compose logs -f
 ```
 
+### Overriding Configuration
+
+Overriding the configuration file can be done by passing the `DB_SYNC_CONFIG` environment
+variable. First, add a bind mount to the `cardano-db-sync` service:
+
+```yaml
+cardano-db-sync:
+  image: cardano-db-sync
+  # <-- Snip -->
+  volumes:
+    - db-sync-data:/var/lib/cexplorer
+    - node-ipc:/node-ipc
+    # Add the bind mount here
+    - ./config/network/mainnet:/data
+  # <-- Snip -->
+```
+
+Set the configuration file with `DB_SYNC_CONFIG`:
+
+```sh
+export DB_SYNC_CONFIG=/data/db-sync-config.json
+docker-compose up -d && docker-compose logs -f
+```
+
 ### Take control
 
 Excluding the `NETWORK` ENV will simply just call the `cardano-db-sync` executable

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -132,7 +132,6 @@ docker-compose up && docker-compose logs -f
 ### Set folder where to download snapshot
 
 The snapshot is downloaded in current working directory. Setting the working directory should allow to choose where the download is done.
-
 For `docker-compose`:
 
 ```yaml
@@ -221,34 +220,27 @@ docker-compose down -f docker-test.yml
 
 ## Building Docker images with Nix
 
-Assuming a base OSX machine with Nix installed. Building a Docker image for cardano-db-sync requires a
-Linux host to compile on. Nix provides a way to do [remote builds](https://nixos.org/manual/nix/unstable/advanced-topics/distributed-builds.html)
-
-Prerequisites:
- * shell account on NixOS Linux machine (ask on Slack)
-   eg. builder@x86_64-linux.example.com
+Building a Docker image for cardano-db-sync requires a Linux host to compile on.
 
 Assuming you want a Linux x86 image run:
 
 ``` shell
-nix build .#legacyPackages.x86_64-linux.dockerImage \
---builders 'ssh://builder@x86_64-linux.example.com x86_64-linux'
+nix build .#packages.x86_64-linux.cardano-db-sync-docker
 ```
 
-At the end it will generate a `tar.gz` file
-eg `/nix/store/arbrn0fs54whkn64m0wrcbl9hjd35byn-docker-image-cardano-db-sync.tar.gz`
+At the end it will generate a `tar.gz` file linked to `./result`
 
 that can be loaded into docker and run as a normal image.
 
 ``` shell
-$ docker load -i /nix/store/arbrn0fs54whkn64m0wrcbl9hjd35byn-docker-image-cardano-db-sync.tar.gz
+$ docker load < result
 
 $ docker image ls
-REPOSITORY                    TAG                                        IMAGE ID       CREATED        SIZE
-inputoutput/cardano-db-sync   066b747a8bfd3791b06ea46c2e793f83ed64967f   f34b029e9c5c   15 hours ago   911MB
+REPOSITORY                    TAG            IMAGE ID       CREATED         SIZE
+cardano-db-sync               latest         a5168d8c04b9   54 years ago    1.16GB
 
 # Run this as
-$ docker run inputoutput/cardano-db-sync:066b747a8bfd3791b06ea46c2e793f83ed64967f
+$ docker run cardano-db-sync
 ```
 
 ## Running SMASH with docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
   cardano-db-sync:
     image: ghcr.io/intersectmbo/cardano-db-sync:13.3.0.0
     environment:
+      - DB_SYNC_CONFIG=${DB_SYNC_CONFIG:-}
       - DISABLE_LEDGER=${DISABLE_LEDGER}
       - NETWORK=${NETWORK:-mainnet}
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
# Description

Add new `DB_SYNC_CONFIG` environment variable to docker compose and add to the docs

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
