### PR TITLE
Update message for insertion of Byron block

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -193,7 +193,7 @@ insertABlock syncEnv firstBlockOfEpoch blk details = do
     when (followingClosely && slotWithinEpoch /= 0 && Byron.blockNumber blk `mod` 20 == 0) $ do
       logInfo tracer $
         mconcat
-          [ "insertByronBlock: continuing epoch "
+          [ "Insert Byron Block: continuing epoch "
           , textShow epoch
           , " (slot "
           , textShow slotWithinEpoch
@@ -203,7 +203,7 @@ insertABlock syncEnv firstBlockOfEpoch blk details = do
           ]
     logger followingClosely tracer $
       mconcat
-        [ "insertByronBlock: epoch "
+        [ "Insert Byron Block: epoch "
         , textShow (unEpochNo $ sdEpochNo details)
         , ", slot "
         , textShow (Byron.slotNumber blk)


### PR DESCRIPTION
Update message to match format for other eras:
- Insert Alonzo Block: epoch 2, slot 172836, block 8640, hash fb9af565b4e... 
- Insert Babbage Block: epoch 3, slot 259215, block 13012, hash 447cc9cf1...

After building and running:
```sh
[db-sync-node:Info:78] [2024-07-29 17:33:49.93 UTC] Starting at epoch 0
[db-sync-node:Info:78] [2024-07-29 17:33:49.93 UTC] insertABOBBoundary: epoch 0, hash 89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4
[db-sync-node:Info:78] [2024-07-29 17:33:49.93 UTC] Setting ConsistencyLevel to Consistent
[db-sync-node:Info:78] [2024-07-29 17:33:50.42 UTC] Insert Byron Block: epoch 0, slot 999, block 1000, hash f84748ae7f413a7f73ddb599fd77e4ed488484c1353c6075a05f30e9c78c9de9
[db-sync-node:Info:78] [2024-07-29 17:33:50.97 UTC] Insert Byron Block: epoch 0, slot 1999, block 2000, hash a82e2b2253a39897f57912cf8fdd70786eb8a2460c2955bb3521642539b87ead
[db-sync-node:Info:78] [2024-07-29 17:33:51.49 UTC] Insert Byron Block: epoch 0, slot 2999, block 3000, hash 3f35d7bf318981c5d4e194172a9f7ff5fe4e006fa5eb7eb7453cf595a69a1426
[db-sync-node:Info:78] [2024-07-29 17:33:52.00 UTC] Insert Byron Block: epoch 0, slot 3999, block 4000, hash 68f5bcce46a2ef622952377854986a44aa79eded70220aaaf61ac84bf90da338
```

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
