### PR TITLE
Update config doc for only_governance preset

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -82,7 +82,7 @@ preset to `"full"` will enable all insert options except `"tx_cbor"`.
 | :-----------    | :----------------------------------------------------------- |
 | ["full"](#Full)             | Enable all options                                           |
 | ["only_utxo"](#only-utxo)   | Only load `block`, `tx`, `tx_out` and `ma_tx_out`.            |
-| ["only_gov"](#only-gov)     | Disable most data except governance data.                    |
+| ["only_governance"](#only-governance)     | Disable most data except governance data.                    |
 | ["disable_all"](#disable-all) | Only load `block`, `tx` and data related to the ledger state |
 
 ### Full
@@ -121,7 +121,7 @@ doesn't use any of its data. When syncing is completed, it loads the whole UTxO 
 to the `tx_out` and `ma_tx_out` tables.  After that db-sync can be restarted with `ledger` set to
 `"disable"` to continue syncing without maintaining the ledger
 
-### Only Gov
+### Only Governance
 
 This is equivalent to setting:
 


### PR DESCRIPTION
# Description

The `only_gov` was renamed to:

https://github.com/IntersectMBO/cardano-db-sync/blob/kderme/13.4.0.0/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs#L404


```json
  "insert_options": {
     "preset": "only_governance"
  },
```


# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
