### PR TITLE
Fix pool_stats for presets override

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
@@ -478,7 +478,7 @@ instance FromJSON SyncInsertOptions where
       <*> obj .:? "plutus" .!= sioPlutus def
       <*> obj .:? "governance" .!= sioGovernance def
       <*> obj .:? "offchain_pool_data" .!= sioOffchainPoolData def
-      <*> obj .:? "pool_stat" .!= sioPoolStats def
+      <*> obj .:? "pool_stats" .!= sioPoolStats def
       <*> obj .:? "json_type" .!= sioJsonType def
       <*> obj .:? "remove_jsonb_from_schema" .!= sioRemoveJsonbFromSchema def
 
@@ -515,10 +515,10 @@ instance FromJSON TxCBORConfig where
       Nothing -> fail $ "unexpected tx_cbor: " <> show v
 
 instance FromJSON PoolStatsConfig where
-  parseJSON = Aeson.withText "pool_stat" $ \v ->
+  parseJSON = Aeson.withText "pool_stats" $ \v ->
     case enableDisableToBool v of
       Just g -> pure (PoolStatsConfig g)
-      Nothing -> fail $ "unexpected pool_stat: " <> show v
+      Nothing -> fail $ "unexpected pool_stats: " <> show v
 
 instance ToJSON TxOutConfig where
   toJSON cfg =

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -103,17 +103,17 @@ This is equivalent to setting:
   "enable": false
 },
 "metadata": {
-  "enable": "false"
+  "enable": false
 },
 "multi_asset": {
-  "enable": "true"
+  "enable": true
 },
 "plutus": {
   "enable": false
 },
 "governance": "disable",
 "offchain_pool_data": "disable"
-"pool_stat": "disable"
+"pool_stats": "disable"
 ```
 
 Initially populates only a few tables, like `block` and `tx`. It maintains a ledger state but
@@ -142,7 +142,7 @@ This is equivalent to setting:
 },
 "governance": "enable",
 "offchain_pool_data": "disable"
-"pool_stat": "disable"
+"pool_stats": "disable"
 
 ```
 
@@ -170,7 +170,7 @@ This is equivalent to setting:
 },
 "governance": "disable",
 "offchain_pool_data": "disable"
-"pool_stat": "disable"
+"pool_stats": "disable"
 ```
 
 Disables almost all data except `block` and `tx` tables.
@@ -491,9 +491,9 @@ This will effect all governance related data/functionality.
 | `"enable"` | Enables fetching offchain metadata.       |
 | `"disable"`| Disables fetching pool offchain metadata. |
 
-## Pool Stat
+## Pool Stats
 
-`pool_stat`
+`pool_stats`
 
  * Type: `string`
 


### PR DESCRIPTION
# Description


In current state the prefix override for `pool_stat` does not work - meaning that this config:

```json
  "insert_options": {
    "preset": "only_utxo",
    "shelley": {
      "enable": true
    },
    "metadata": {
        "enable": true
    },
    "ledger": "enable",
    "multi_asset": {
      "enable": true
    },
    "plutus": {
      "enable": true
    },
    "offchain_pool_data": "enable",
    "governance": "enable",
    "pool_stat": "enable",
  },
```

will result in:
```
[db-sync-node:Info:6] [2024-08-12 12:21:18.29 UTC] SyncOptions {soptEpochAndCacheEnabled = False, soptAbortOnInvalid = True, soptCache = True, soptSkipFix = False, soptOnlyFix = False, soptPruneConsumeMigration = PruneConsumeMigration {pcmPruneTxOut = True, pcmConsumeOrPruneTxOut = True, pcmSkipTxIn = True}, soptInsertOptions = InsertOptions {ioTxCBOR = False, ioInOut = True, ioUseLedger = True, ioShelley = True, ioRewards = True, ioMultiAssets = True, ioMetadata = True, ioKeepMetadataNames = Nothing, ioPlutusExtra = True, ioOffChainPoolData = True, ioPoolStats = False, ioGov = True, ioRemoveJsonbFromSchema = False}, snapshotEveryFollowing = 500, snapshotEveryLagging = 10000}
```

where:

`ioPoolStats = False`

and empty table `pool_stats`.

</br>

In order to fix it one needs to use `pool_stats` (plural) instead of `pool_stat` :

```
    "pool_stats": "enable",
```

I looked into the code and decided to make small changes which are not necessary but were a bit confusing to me.
I also updated `configuration.md` document to reflect issue.


# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
