### PR TITLE
Fix: Remove constraint `concurrent-output < 1.10.19`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -53,12 +53,6 @@ package cryptonite
 package text
   flags: -simdutf
 
--- concurrent-output is incompatible with our haskell.nix version due to
--- arch(wasm32).
--- TODO[sgillespie]: Upgrade haskell.nix
-constraints:
-  , concurrent-output < 1.10.19
-
 -- ---------------------------------------------------------
 -- Enable tests
 


### PR DESCRIPTION
# Description

Fixes #1818. This was fixed in haskell.nix at e166d754a739f5e41d389c537498ccdc6150be0b.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
