### PR TITLE
Fix consumed_tx_out for Byron

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -316,7 +316,7 @@ insertByronTx' syncEnv blkId tx blockIndex = do
     mapM_ (insertTxIn tracer txId) resolvedInputs
   whenConsumeOrPruneTxOut syncEnv $
     lift $
-      DB.updateListTxOutConsumedByTxId (prepUpdate <$> resolvedInputs)
+      DB.updateListTxOutConsumedByTxId (prepUpdate txId <$> resolvedInputs)
   -- fees are being returned so we can sum them and put them in cache to use when updating epochs
   pure $ unDbLovelace $ vfFee valFee
   where
@@ -331,7 +331,7 @@ insertByronTx' syncEnv blkId tx blockIndex = do
         SNErrInvariant loc ei -> SNErrInvariant loc (annotateInvariantTx (Byron.taTx tx) ei)
         _other -> ee
 
-    prepUpdate (_, txId, txOutId, _) = (txOutId, txId)
+    prepUpdate txId (_, _, txOutId, _) = (txOutId, txId)
 
 insertTxOut ::
   (MonadBaseControl IO m, MonadIO m) =>


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/cardano-db-sync/issues/1821

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
