### PR TITLE
Cherry-pick fixes for consumed migration and committee fkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-db-sync
 
+## 13.4.1.0
+- Fix consumed_by option for Byron inputs. A migration fixes old wrong values in place. [#1821]
+- Fix only-utxo preset populating the metadata instead of the multiassets
+
 ## 13.4.0.0
 
 - Voting metadata parsing falls back to CIP-100 when CIP-108 or CIP-119 is not followed [#1779]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for cardano-db-sync
 
+## 13.5.0.0
+- Fix a crtitical bug with committee foreign key, that could cause crashes
+
 ## 13.4.1.0
 - Fix consumed_by option for Byron inputs. A migration fixes old wrong values in place. [#1821]
 - Fix only-utxo preset populating the metadata instead of the multiassets

--- a/cardano-chain-gen/cardano-chain-gen.cabal
+++ b/cardano-chain-gen/cardano-chain-gen.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-chain-gen
-version:                13.4.0.0
+version:                13.4.1.0
 synopsis:               A fake chain generator for testing cardano DB sync.
 description:            A fake chain generator for testing cardano DB sync.
 homepage:               https://github.com/IntersectMBO/cardano-db-sync

--- a/cardano-chain-gen/cardano-chain-gen.cabal
+++ b/cardano-chain-gen/cardano-chain-gen.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-chain-gen
-version:                13.4.1.0
+version:                13.5.0.0
 synopsis:               A fake chain generator for testing cardano DB sync.
 description:            A fake chain generator for testing cardano DB sync.
 homepage:               https://github.com/IntersectMBO/cardano-db-sync

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db-sync
-version:                13.4.1.0
+version:                13.5.0.0
 synopsis:               The Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database.

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db-sync
-version:                13.4.0.0
+version:                13.4.1.0
 synopsis:               The Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database.
@@ -119,6 +119,7 @@ library
 
                         Cardano.DbSync.Rollback
 
+                        Cardano.DbSync.Fix.ConsumedBy
                         Cardano.DbSync.Fix.EpochStake
                         Cardano.DbSync.Fix.PlutusDataBytes
                         Cardano.DbSync.Fix.PlutusScripts

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -8,6 +8,7 @@
 
 module Cardano.DbSync.Era.Byron.Insert (
   insertByronBlock,
+  resolveTxInputs,
 ) where
 
 import Cardano.BM.Trace (Trace, logDebug, logInfo)

--- a/cardano-db-sync/src/Cardano/DbSync/Fix/ConsumedBy.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Fix/ConsumedBy.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.DbSync.Fix.ConsumedBy (fixConsumedBy) where
+
+import Cardano.BM.Trace (Trace, logWarning)
+import qualified Cardano.Chain.Block as Byron hiding (blockHash)
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Crypto as Crypto (serializeCborHash)
+import qualified Cardano.Db as DB
+import Cardano.DbSync.Era.Byron.Insert
+import Cardano.DbSync.Era.Byron.Util (blockPayload, unTxHash)
+import Cardano.DbSync.Era.Util
+import Cardano.DbSync.Error
+import Cardano.DbSync.Types
+import Cardano.Prelude hiding (length)
+import Database.Persist.SqlBackend.Internal
+import Ouroboros.Consensus.Byron.Ledger (ByronBlock (..))
+import Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
+
+fixConsumedBy :: SqlBackend -> Trace IO Text -> Integer -> CardanoBlock -> IO (Integer, Bool)
+fixConsumedBy backend tracer lastSize cblk = case cblk of
+  BlockByron blk -> (\(n, bl) -> (n + lastSize, bl)) <$> fixBlock backend tracer blk
+  _ -> pure (lastSize, True)
+
+fixBlock :: SqlBackend -> Trace IO Text -> ByronBlock -> IO (Integer, Bool)
+fixBlock backend tracer bblk = case byronBlockRaw bblk of
+  Byron.ABOBBoundary _ -> pure (0, False)
+  Byron.ABOBBlock blk -> do
+    runReaderT (fix 0 (blockPayload blk)) backend
+  where
+    fix totalSize [] = pure (totalSize, False)
+    fix totalSize (tx : txs) = do
+      mn <- runExceptT $ fixTx tx
+      case mn of
+        Right n -> fix (totalSize + n) txs
+        Left err -> do
+          liftIO $
+            logWarning tracer $
+              mconcat
+                [ "While fixing tx "
+                , textShow tx
+                , ", encountered error "
+                , textShow err
+                ]
+          pure (totalSize, True)
+
+fixTx :: MonadIO m => Byron.TxAux -> ExceptT SyncNodeError (ReaderT SqlBackend m) Integer
+fixTx tx = do
+  txId <- liftLookupFail "resolving tx" $ DB.queryTxId txHash
+  resolvedInputs <- mapM resolveTxInputs (toList $ Byron.txInputs (Byron.taTx tx))
+  lift $ DB.updateListTxOutConsumedByTxId (prepUpdate txId <$> resolvedInputs)
+  pure $ fromIntegral $ length resolvedInputs
+  where
+    txHash = unTxHash $ Crypto.serializeCborHash (Byron.taTx tx)
+    prepUpdate txId (_, _, txOutId, _) = (txOutId, txId)

--- a/cardano-db-sync/src/Cardano/DbSync/Fix/ConsumedBy.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Fix/ConsumedBy.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Cardano.DbSync.Fix.ConsumedBy (fixConsumedBy) where
+module Cardano.DbSync.Fix.ConsumedBy (FixEntry, fixConsumedBy, fixEntriesConsumed) where
 
 import Cardano.BM.Trace (Trace, logWarning)
 import qualified Cardano.Chain.Block as Byron hiding (blockHash)
@@ -12,44 +12,45 @@ import Cardano.DbSync.Era.Byron.Util (blockPayload, unTxHash)
 import Cardano.DbSync.Era.Util
 import Cardano.DbSync.Error
 import Cardano.DbSync.Types
-import Cardano.Prelude hiding (length)
+import Cardano.Prelude hiding (length, (.))
 import Database.Persist.SqlBackend.Internal
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock (..))
 import Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
 
-fixConsumedBy :: SqlBackend -> Trace IO Text -> Integer -> CardanoBlock -> IO (Integer, Bool)
-fixConsumedBy backend tracer lastSize cblk = case cblk of
-  BlockByron blk -> (\(n, bl) -> (n + lastSize, bl)) <$> fixBlock backend tracer blk
-  _ -> pure (lastSize, True)
+type FixEntry = (DB.TxOutId, DB.TxId)
 
-fixBlock :: SqlBackend -> Trace IO Text -> ByronBlock -> IO (Integer, Bool)
+-- | Nothing when the syncing must stop.
+fixConsumedBy :: SqlBackend -> Trace IO Text -> CardanoBlock -> IO (Maybe [FixEntry])
+fixConsumedBy backend tracer cblk = case cblk of
+  BlockByron blk -> fixBlock backend tracer blk
+  _ -> pure Nothing
+
+fixBlock :: SqlBackend -> Trace IO Text -> ByronBlock -> IO (Maybe [FixEntry])
 fixBlock backend tracer bblk = case byronBlockRaw bblk of
-  Byron.ABOBBoundary _ -> pure (0, False)
+  Byron.ABOBBoundary _ -> pure $ Just []
   Byron.ABOBBlock blk -> do
-    runReaderT (fix 0 (blockPayload blk)) backend
-  where
-    fix totalSize [] = pure (totalSize, False)
-    fix totalSize (tx : txs) = do
-      mn <- runExceptT $ fixTx tx
-      case mn of
-        Right n -> fix (totalSize + n) txs
-        Left err -> do
-          liftIO $
-            logWarning tracer $
-              mconcat
-                [ "While fixing tx "
-                , textShow tx
-                , ", encountered error "
-                , textShow err
-                ]
-          pure (totalSize, True)
+    mEntries <- runReaderT (runExceptT $ mapM fixTx (blockPayload blk)) backend
+    case mEntries of
+      Right newEntries -> pure $ Just $ concat newEntries
+      Left err -> do
+        liftIO $
+          logWarning tracer $
+            mconcat
+              [ "While fixing block "
+              , textShow bblk
+              , ", encountered error "
+              , textShow err
+              ]
+        pure Nothing
 
-fixTx :: MonadIO m => Byron.TxAux -> ExceptT SyncNodeError (ReaderT SqlBackend m) Integer
+fixTx :: MonadIO m => Byron.TxAux -> ExceptT SyncNodeError (ReaderT SqlBackend m) [FixEntry]
 fixTx tx = do
   txId <- liftLookupFail "resolving tx" $ DB.queryTxId txHash
   resolvedInputs <- mapM resolveTxInputs (toList $ Byron.txInputs (Byron.taTx tx))
-  lift $ DB.updateListTxOutConsumedByTxId (prepUpdate txId <$> resolvedInputs)
-  pure $ fromIntegral $ length resolvedInputs
+  pure (prepUpdate txId <$> resolvedInputs)
   where
     txHash = unTxHash $ Crypto.serializeCborHash (Byron.taTx tx)
     prepUpdate txId (_, _, txOutId, _) = (txOutId, txId)
+
+fixEntriesConsumed :: SqlBackend -> Trace IO Text -> [FixEntry] -> IO ()
+fixEntriesConsumed backend tracer = DB.runDbIohkLogging backend tracer . DB.updateListTxOutConsumedByTxId

--- a/cardano-db-sync/src/Cardano/DbSync/Sync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Sync.hs
@@ -214,7 +214,7 @@ dbSyncProtocols syncEnv metricsSetters tc codecConfig version bversion =
       case consumedFixed of
         Nothing -> oldActionFixes channel
         Just wrongEntriesSize | wrongEntriesSize == 0 -> do
-          logInfo tracer "Found no wrong entries"
+          logInfo tracer "Found no wrong consumed_by_tx_id entries"
           oldActionFixes channel
         Just wrongEntriesSize -> do
           logInfo tracer $

--- a/cardano-db-tool/cardano-db-tool.cabal
+++ b/cardano-db-tool/cardano-db-tool.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db-tool
-version:                13.4.0.0
+version:                13.4.1.0
 synopsis:               Utilities to manage the cardano-db-sync databases.
 description:            Utilities and executable, used to manage and validate the
                         PostgreSQL db and the ledger database of the cardano-db-sync node

--- a/cardano-db-tool/cardano-db-tool.cabal
+++ b/cardano-db-tool/cardano-db-tool.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db-tool
-version:                13.4.1.0
+version:                13.5.0.0
 synopsis:               Utilities to manage the cardano-db-sync databases.
 description:            Utilities and executable, used to manage and validate the
                         PostgreSQL db and the ledger database of the cardano-db-sync node

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db
-version:                13.3.0.0
+version:                13.4.1.0
 synopsis:               A base PostgreSQL component for the cardano-db-sync node.
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db
-version:                13.4.1.0
+version:                13.5.0.0
 synopsis:               A base PostgreSQL component for the cardano-db-sync node.
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.

--- a/cardano-db/src/Cardano/Db/Migration/Extra/CosnumedTxOut/Queries.hs
+++ b/cardano-db/src/Cardano/Db/Migration/Extra/CosnumedTxOut/Queries.hs
@@ -141,6 +141,14 @@ _validateMigration trce = do
                 ]
           pure False
 
+queryWrongConsumedBy :: MonadIO m => ReaderT SqlBackend m Word64
+queryWrongConsumedBy = do
+  res <- select $ do
+    txOut <- from $ table @TxOut
+    where_ (just (txOut ^. TxOutTxId) E.==. txOut ^. TxOutConsumedByTxId)
+    pure countRows
+  pure $ maybe 0 unValue (listToMaybe res)
+
 --------------------------------------------------------------------------------------------------
 -- Inserts
 --------------------------------------------------------------------------------------------------

--- a/cardano-db/src/Cardano/Db/Multiplex.hs
+++ b/cardano-db/src/Cardano/Db/Multiplex.hs
@@ -10,6 +10,7 @@ module Cardano.Db.Multiplex (
   setNullTxOut,
   runExtraMigrations,
   ExtraCons.deleteConsumedTxOut,
+  ExtraCons.queryWrongConsumedBy,
 ) where
 
 import Cardano.BM.Trace (Trace, logInfo)

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -641,7 +641,7 @@ share
     quorumDenominator    Word64
 
   CommitteeMember
-    committeeId          CommitteeId   -- here intentionally we use foreign keys
+    committeeId          CommitteeId          OnDeleteCascade -- here intentionally we use foreign keys
     committeeHashId      CommitteeHashId      noreference
     expirationEpoch      Word64               sqltype=word31type
 

--- a/cardano-db/test/cardano-db-test.cabal
+++ b/cardano-db/test/cardano-db-test.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db-test
-version:                13.4.0.0
+version:                13.4.1.0
 synopsis:               Tests for the base functionality of the cardano-db library
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.

--- a/cardano-db/test/cardano-db-test.cabal
+++ b/cardano-db/test/cardano-db-test.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-db-test
-version:                13.4.1.0
+version:                13.5.0.0
 synopsis:               Tests for the base functionality of the cardano-db library
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.

--- a/cardano-smash-server/cardano-smash-server.cabal
+++ b/cardano-smash-server/cardano-smash-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-smash-server
-version:                13.3.0.0
+version:                13.4.1.0
 synopsis:               The Cardano smash server
 description:            Please see the README on GitHub at
                         <https://github.com/IntersectMBO/cardano-db-sync/cardano-smash-server/#readme>

--- a/cardano-smash-server/cardano-smash-server.cabal
+++ b/cardano-smash-server/cardano-smash-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:          3.6
 
 name:                   cardano-smash-server
-version:                13.4.1.0
+version:                13.5.0.0
 synopsis:               The Cardano smash server
 description:            Please see the README on GitHub at
                         <https://github.com/IntersectMBO/cardano-db-sync/cardano-smash-server/#readme>

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,7 +1,5 @@
 # Schema Documentation for cardano-db-sync
 
-**Note:** This file is auto-generated from the documentation in cardano-db/src/Cardano/Db/Schema.hs by the command `cabal run -- gen-schema-docs doc/schema.md`. This document should only be updated during the release process and updated on the release branch.
-
 ### `schema_version`
 
 The version of the database schema. Schema versioning is split into three stages as detailed below. This table should only ever have a single row.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
         max-file: "10"
 
   cardano-db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.4.0.0
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.5.0.0
     environment:
       - DB_SYNC_CONFIG=${DB_SYNC_CONFIG:-}
       - DISABLE_LEDGER=${DISABLE_LEDGER}

--- a/schema/migration-2-0043-20240828.sql
+++ b/schema/migration-2-0043-20240828.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 43 THEN
+    EXECUTE 'ALTER TABLE "committee_member" DROP CONSTRAINT "committee_member_committee_id_fkey"' ;
+    EXECUTE 'ALTER TABLE "committee_member" ADD CONSTRAINT "committee_member_committee_id_fkey" FOREIGN KEY("committee_id") REFERENCES "committee"("id") ON DELETE CASCADE  ON UPDATE RESTRICT' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
# Description

Cherry-picks https://github.com/IntersectMBO/cardano-db-sync/pull/1829 and https://github.com/IntersectMBO/cardano-db-sync/pull/1830 to master

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
