### PR TITLE
Disable usage of openssl

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -63,7 +63,9 @@ test-show-details: direct
 write-ghc-environment-files: always
 
 package snap-server
-  flags: +openssl
+  -- This flag is only needed for a component of `cardano-node` and then
+  -- only if the `cardano-node` is compiled with `+rtview`.
+  flags: -openssl
 
 allow-newer:
   swagger2:aeson


### PR DESCRIPTION
`OpenSSL` is used via `HsOpenSSL` which currently cannot be built if the version of GCC being used by GHC is >= 14.2 and even if that were fixed, `HsOpenSSL` is likely to break again in early 2025:

    https://github.com/haskell-cryptography/HsOpenSSL/issues/95

Finally, `openssl` support is only needed if `cardano-node` is compiled with the `+rtview` flag, which is not the case for `db-sync`.

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
