### PR TITLE
WIP: Trim blocks before applying ledger state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -92,3 +92,17 @@ source-repository-package
     trace-dispatcher
     trace-forward
     trace-resources
+
+source-repository-package
+  type: git
+  location: https://github.com/sgillespie/cardano-ledger
+  tag: bce849adad593f6e12faf0bb036604db9ee740c8
+  --sha256: sha256-Pq24tyvG8pWSGDXs7ukrUui+gfnDzE/DK+Rv1KYhPiQ=
+  subdir:
+    libs/cardano-ledger-core
+    eras/shelley/impl
+    eras/allegra/impl
+    eras/mary/impl
+    eras/alonzo/impl
+    eras/babbage/impl
+    eras/conway/impl


### PR DESCRIPTION
# Description

Reduces the total size of the ledger size by tampering with blocks before applying them to the ledger state. In this change, we clear out all multiassets from txouts.

To test this, I removed all ledger state snapshots and started DB sync, which forces it to replay the ledger state for genesis. I've used the `time` program (not the bash builtin) to measure the maximum amount of memory as reported by the OS (Resident Set Size).

Latest revision in master:

```
        Command being timed: "cardano-db-sync --config db-sync-config.json --socket-path /run/cardano-node/node.socket --schema-dir ../../cardano-db-sync/schema --state-dir ledger"
        User time (seconds): 39703.05
        System time (seconds): 6046.32
        Percent of CPU this job got: 137%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 9:15:57
        Maximum resident set size (kbytes): 19599504
        Major (requiring I/O) page faults: 3124
        Minor (reclaiming a frame) page faults: 7021739
        Voluntary context switches: 37058762
        Involuntary context switches: 1129102
        Page size (bytes): 4096
        Exit status: 0
```

Using the changes in this PR:

```
        Command being timed: "cardano-db-sync --config db-sync-config.json --socket-path /run/cardano-node/node.socket --schema-dir ../../cardano-db-sync/schema --state-dir ledger"
        User time (seconds): 50988.88
        System time (seconds): 4944.32
        Percent of CPU this job got: 78%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 19:53:47
        Maximum resident set size (kbytes): 14068792
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 4904552
        Voluntary context switches: 33438678
        Involuntary context switches: 638268
        Page size (bytes): 4096
        Exit status: 0
```

**Important**: Note that this PR can't be merged until the corresponding cardano-ledger PR is integrated and released
# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
