### PR TITLE
1870 - add variant for collateral txout

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -178,7 +178,7 @@ runExtraMigrationsMaybe :: SyncEnv -> IO ()
 runExtraMigrationsMaybe syncEnv = do
   let pcm = getPruneConsume syncEnv
       txOutTableType = getTxOutTableType syncEnv
-  logInfo (getTrace syncEnv) $ textShow pcm
+  logInfo (getTrace syncEnv) $ "runExtraMigrationsMaybe: " <> textShow pcm
   DB.runDbIohkNoLogging (envBackend syncEnv) $
     DB.runExtraMigrations
       (getTrace syncEnv)

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -243,6 +243,7 @@ insertTxOutsByron syncEnv disInOut blkId (address, value) = do
         , V.txOutReferenceScriptId = Nothing
         , V.txOutAddressId = addrDetailId
         , V.txOutConsumedByTxId = Nothing
+        , V.txOutStakeAddressId = Nothing
         }
 
     mkVAddress :: ByteString -> V.Address

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -383,6 +383,7 @@ insertTxOutByron syncEnv _hasConsumed bootStrap txId index txout =
         , V.txOutReferenceScriptId = Nothing
         , V.txOutTxId = txId
         , V.txOutValue = DbLovelace (Byron.unsafeGetLovelace $ Byron.txOutValue txout)
+        , V.txOutStakeAddressId = Nothing
         }
 
     vAddress :: V.Address

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -285,6 +285,7 @@ insertTxOuts syncEnv trce blkId (TxIn txInId _, txOut) = do
         , V.txOutReferenceScriptId = Nothing
         , V.txOutTxId = txId
         , V.txOutValue = Generic.coinToDbLovelace (txOut ^. Core.valueTxOutL)
+        , V.txOutStakeAddressId = Nothing -- No stake addresses in Shelley Genesis
         }
 
     vAddress :: V.Address

--- a/cardano-db/src/Cardano/Db/Operations/Insert.hs
+++ b/cardano-db/src/Cardano/Db/Operations/Insert.hs
@@ -44,7 +44,6 @@ module Cardano.Db.Operations.Insert (
   insertTxIn,
   insertManyTxMint,
   insertManyTxMetadata,
-  insertCollateralTxOut,
   insertWithdrawal,
   insertRedeemer,
   insertCostModel,
@@ -297,9 +296,6 @@ insertManyTxMint = insertMany' "TxMint"
 
 insertTxCBOR :: (MonadBaseControl IO m, MonadIO m) => TxCbor -> ReaderT SqlBackend m TxCborId
 insertTxCBOR = insertUnchecked "TxCBOR"
-
-insertCollateralTxOut :: (MonadBaseControl IO m, MonadIO m) => CollateralTxOut -> ReaderT SqlBackend m CollateralTxOutId
-insertCollateralTxOut = insertUnchecked "CollateralTxOut"
 
 insertWithdrawal :: (MonadBaseControl IO m, MonadIO m) => Withdrawal -> ReaderT SqlBackend m WithdrawalId
 insertWithdrawal = insertUnchecked "Withdrawal"

--- a/cardano-db/src/Cardano/Db/Operations/Other/ConsumedTxOut.hs
+++ b/cardano-db/src/Cardano/Db/Operations/Other/ConsumedTxOut.hs
@@ -114,7 +114,7 @@ runExtraMigrations trce txOutTableType blockNoDiff pcm = do
       DBExtraMigration "runExtraMigrations: The configuration option 'tx_out.use_address_table' was previously set and the database updated. Unfortunately reverting this isn't possible."
   -- Has the user given txout address config && the migration wasn't previously set
   when (isTxOutVariant && not isTxOutAddressSet) $ do
-    updateTxOutAndCreateAddress
+    updateTxOutAndCreateAddress trce
     insertExtraMigration TxOutAddressPreviouslySet
   -- first check if pruneTxOut flag is missing and it has previously been used
   when (isPruneTxOutPreviouslySet migrationValues && not (pcmPruneTxOut pcm)) $
@@ -407,18 +407,29 @@ createPruneConstraintTxOut = do
     exceptHandler e =
       liftIO $ throwIO (DBPruneConsumed $ show e)
 
+-- Be very mindfull that these queries can fail silently and make tests fail making it hard to know why.
+-- To help mitigate this, logs are printed after each query is ran, so one can know where it stopped.
 updateTxOutAndCreateAddress ::
   forall m.
   ( MonadBaseControl IO m
   , MonadIO m
   ) =>
+  Trace IO Text ->
   ReaderT SqlBackend m ()
-updateTxOutAndCreateAddress = do
+updateTxOutAndCreateAddress trc = do
   handle exceptHandler $ rawExecute dropViewsQuery []
+  liftIO $ logInfo trc "updateTxOutAndCreateAddress: Dropped views"
   handle exceptHandler $ rawExecute alterTxOutQuery []
+  liftIO $ logInfo trc "updateTxOutAndCreateAddress: Altered tx_out"
+  handle exceptHandler $ rawExecute alterCollateralTxOutQuery []
+  liftIO $ logInfo trc "updateTxOutAndCreateAddress: Altered collateral_tx_out"
   handle exceptHandler $ rawExecute createAddressTableQuery []
+  liftIO $ logInfo trc "updateTxOutAndCreateAddress: Created address table"
   handle exceptHandler $ rawExecute createIndexPaymentCredQuery []
+  liftIO $ logInfo trc "updateTxOutAndCreateAddress: Created index payment_cred"
   handle exceptHandler $ rawExecute createIndexRawQuery []
+  liftIO $ logInfo trc "updateTxOutAndCreateAddress: Created index raw"
+  liftIO $ logInfo trc "updateTxOutAndCreateAddress: Completed"
   where
     dropViewsQuery =
       Text.unlines
@@ -432,8 +443,16 @@ updateTxOutAndCreateAddress = do
         , "  ADD COLUMN \"address_id\" INT8 NOT NULL,"
         , "  DROP COLUMN \"address\","
         , "  DROP COLUMN \"address_has_script\","
-        , "  DROP COLUMN \"payment_cred\","
-        , "  DROP COLUMN \"stake_address_id\""
+        , "  DROP COLUMN \"payment_cred\""
+        ]
+
+    alterCollateralTxOutQuery =
+      Text.unlines
+        [ "ALTER TABLE \"collateral_tx_out\""
+        , "  ADD COLUMN \"address_id\" INT8 NOT NULL,"
+        , "  DROP COLUMN \"address\","
+        , "  DROP COLUMN \"address_has_script\","
+        , "  DROP COLUMN \"payment_cred\""
         ]
 
     createAddressTableQuery =

--- a/cardano-db/src/Cardano/Db/Operations/TxOut/TxOutInsert.hs
+++ b/cardano-db/src/Cardano/Db/Operations/TxOut/TxOutInsert.hs
@@ -8,7 +8,7 @@
 module Cardano.Db.Operations.TxOut.TxOutInsert where
 
 import Cardano.Db.Operations.Insert (insertMany', insertUnchecked)
-import Cardano.Db.Operations.Types (MaTxOutIdW (..), MaTxOutW (..), TxOutIdW (..), TxOutW (..))
+import Cardano.Db.Operations.Types (CollateralTxOutIdW (..), CollateralTxOutW (..), MaTxOutIdW (..), MaTxOutW (..), TxOutIdW (..), TxOutW (..))
 import qualified Cardano.Db.Schema.Core.TxOut as C
 import qualified Cardano.Db.Schema.Variant.TxOut as V
 import Control.Monad.IO.Class (MonadIO)
@@ -90,3 +90,13 @@ insertManyMaTxOut maTxOutWs = do
     extractVariantMaTxOut :: MaTxOutW -> V.MaTxOut
     extractVariantMaTxOut (VMaTxOutW maTxOut) = maTxOut
     extractVariantMaTxOut (CMaTxOutW _) = error "Unexpected CMaTxOutW in VariantMaTxOut list"
+
+insertCollateralTxOut :: (MonadBaseControl IO m, MonadIO m) => CollateralTxOutW -> ReaderT SqlBackend m CollateralTxOutIdW
+insertCollateralTxOut collateralTxOutW =
+  case collateralTxOutW of
+    CCollateralTxOutW txOut -> do
+      val <- insertUnchecked "CollateralTxOut" txOut
+      pure $ CCollateralTxOutIdW val
+    VCollateralTxOutW txOut -> do
+      val <- insertUnchecked "CollateralTxOut" txOut
+      pure $ VCollateralTxOutIdW val

--- a/cardano-db/src/Cardano/Db/Operations/Types.hs
+++ b/cardano-db/src/Cardano/Db/Operations/Types.hs
@@ -21,6 +21,10 @@ import Database.Persist.Sql (PersistField)
 data TxOutTableType = TxOutCore | TxOutVariantAddress
   deriving (Eq, Show)
 
+--------------------------------------------------------------------------------
+-- TxOut
+--------------------------------------------------------------------------------
+
 -- | A wrapper for TxOut that allows us to handle both Core and Variant TxOuts
 data TxOutW
   = CTxOutW !C.TxOut
@@ -42,85 +46,20 @@ data TxOutIdW
   | VTxOutIdW !V.TxOutId
   deriving (Show)
 
--- Pattern synonyms for easier construction
-pattern CoreTxOutId :: C.TxOutId -> TxOutIdW
-pattern CoreTxOutId txOutId = CTxOutIdW txOutId
-
-pattern VariantTxOutId :: V.TxOutId -> TxOutIdW
-pattern VariantTxOutId txOutId = VTxOutIdW txOutId
-
--- | A wrapper for MaTxOut
-data MaTxOutW
-  = CMaTxOutW !C.MaTxOut
-  | VMaTxOutW !V.MaTxOut
-  deriving (Show)
-
-pattern CoreMaTxOut :: C.MaTxOut -> MaTxOutW
-pattern CoreMaTxOut maTxOut = CMaTxOutW maTxOut
-
-pattern VariantMaTxOut :: V.MaTxOut -> MaTxOutW
-pattern VariantMaTxOut maTxOut = VMaTxOutW maTxOut
-
--- | A wrapper for MaTxOut
-data MaTxOutIdW
-  = CMaTxOutIdW !C.MaTxOutId
-  | VMaTxOutIdW !V.MaTxOutId
-  deriving (Show)
-
-pattern CoreMaTxOutId :: C.MaTxOutId -> MaTxOutIdW
-pattern CoreMaTxOutId maTxOutId = CMaTxOutIdW maTxOutId
-
-pattern VariantMaTxOutId :: V.MaTxOutId -> MaTxOutIdW
-pattern VariantMaTxOutId maTxOutId = VMaTxOutIdW maTxOutId
-
--- | UtxoQueryResult which has utxoAddress that can come from Core or Variant TxOut
-data UtxoQueryResult = UtxoQueryResult
-  { utxoTxOutW :: TxOutW
-  , utxoAddress :: Text
-  , utxoTxHash :: ByteString
-  }
-
---------------------------------------------------------------------------------
 -- TxOut fields for a given TxOutTableType
---------------------------------------------------------------------------------
 class (PersistEntity (TxOutTable a), PersistField (TxOutIdFor a)) => TxOutFields (a :: TxOutTableType) where
   type TxOutTable a :: Type
   type TxOutIdFor a :: Type
+  txOutIdField :: EntityField (TxOutTable a) (TxOutIdFor a)
   txOutTxIdField :: EntityField (TxOutTable a) TxId
   txOutIndexField :: EntityField (TxOutTable a) Word64
   txOutValueField :: EntityField (TxOutTable a) DbLovelace
-  txOutIdField :: EntityField (TxOutTable a) (TxOutIdFor a)
   txOutDataHashField :: EntityField (TxOutTable a) (Maybe ByteString)
   txOutInlineDatumIdField :: EntityField (TxOutTable a) (Maybe DatumId)
   txOutReferenceScriptIdField :: EntityField (TxOutTable a) (Maybe ScriptId)
   txOutConsumedByTxIdField :: EntityField (TxOutTable a) (Maybe TxId)
 
---------------------------------------------------------------------------------
--- Multi-asset fields for a given TxOutTableType
---------------------------------------------------------------------------------
-class (PersistEntity (MaTxOutTable a)) => MaTxOutFields (a :: TxOutTableType) where
-  type MaTxOutTable a :: Type
-  type MaTxOutIdFor a :: Type
-  maTxOutTxOutIdField :: EntityField (MaTxOutTable a) (TxOutIdFor a)
-  maTxOutIdentField :: EntityField (MaTxOutTable a) MultiAssetId
-  maTxOutQuantityField :: EntityField (MaTxOutTable a) DbWord64
-
---------------------------------------------------------------------------------
--- Address-related fields for TxOutVariantAddress only
---------------------------------------------------------------------------------
-class AddressFields (a :: TxOutTableType) where
-  type AddressTable a :: Type
-  type AddressIdFor a :: Type
-  addressField :: EntityField (AddressTable a) Text
-  addressRawField :: EntityField (AddressTable a) ByteString
-  addressHasScriptField :: EntityField (AddressTable a) Bool
-  addressPaymentCredField :: EntityField (AddressTable a) (Maybe ByteString)
-  addressStakeAddressIdField :: EntityField (AddressTable a) (Maybe StakeAddressId)
-  addressIdField :: EntityField (AddressTable a) (AddressIdFor a)
-
---------------------------------------------------------------------------------
--- Instances for TxOutCore
---------------------------------------------------------------------------------
+-- TxOutCore fields
 instance TxOutFields 'TxOutCore where
   type TxOutTable 'TxOutCore = C.TxOut
   type TxOutIdFor 'TxOutCore = C.TxOutId
@@ -133,16 +72,7 @@ instance TxOutFields 'TxOutCore where
   txOutReferenceScriptIdField = C.TxOutReferenceScriptId
   txOutConsumedByTxIdField = C.TxOutConsumedByTxId
 
-instance MaTxOutFields 'TxOutCore where
-  type MaTxOutTable 'TxOutCore = C.MaTxOut
-  type MaTxOutIdFor 'TxOutCore = C.MaTxOutId
-  maTxOutTxOutIdField = C.MaTxOutTxOutId
-  maTxOutIdentField = C.MaTxOutIdent
-  maTxOutQuantityField = C.MaTxOutQuantity
-
---------------------------------------------------------------------------------
--- Instances for TxOutVariantAddress
---------------------------------------------------------------------------------
+-- TxOutVariantAddress fields
 instance TxOutFields 'TxOutVariantAddress where
   type TxOutTable 'TxOutVariantAddress = V.TxOut
   type TxOutIdFor 'TxOutVariantAddress = V.TxOutId
@@ -155,13 +85,21 @@ instance TxOutFields 'TxOutVariantAddress where
   txOutReferenceScriptIdField = V.TxOutReferenceScriptId
   txOutConsumedByTxIdField = V.TxOutConsumedByTxId
 
-instance MaTxOutFields 'TxOutVariantAddress where
-  type MaTxOutTable 'TxOutVariantAddress = V.MaTxOut
-  type MaTxOutIdFor 'TxOutVariantAddress = V.MaTxOutId
-  maTxOutTxOutIdField = V.MaTxOutTxOutId
-  maTxOutIdentField = V.MaTxOutIdent
-  maTxOutQuantityField = V.MaTxOutQuantity
+--------------------------------------------------------------------------------
+-- Address
+-- related fields for TxOutVariantAddress only
+--------------------------------------------------------------------------------
+class AddressFields (a :: TxOutTableType) where
+  type AddressTable a :: Type
+  type AddressIdFor a :: Type
+  addressField :: EntityField (AddressTable a) Text
+  addressRawField :: EntityField (AddressTable a) ByteString
+  addressHasScriptField :: EntityField (AddressTable a) Bool
+  addressPaymentCredField :: EntityField (AddressTable a) (Maybe ByteString)
+  addressStakeAddressIdField :: EntityField (AddressTable a) (Maybe StakeAddressId)
+  addressIdField :: EntityField (AddressTable a) (AddressIdFor a)
 
+-- TxOutVariant fields
 instance AddressFields 'TxOutVariantAddress where
   type AddressTable 'TxOutVariantAddress = V.Address
   type AddressIdFor 'TxOutVariantAddress = V.AddressId
@@ -171,6 +109,76 @@ instance AddressFields 'TxOutVariantAddress where
   addressPaymentCredField = V.AddressPaymentCred
   addressStakeAddressIdField = V.AddressStakeAddressId
   addressIdField = V.AddressId
+
+--------------------------------------------------------------------------------
+-- MaTxOut
+--------------------------------------------------------------------------------
+
+-- | A wrapper for MaTxOut
+data MaTxOutW
+  = CMaTxOutW !C.MaTxOut
+  | VMaTxOutW !V.MaTxOut
+  deriving (Show)
+
+-- | A wrapper for MaTxOutId
+data MaTxOutIdW
+  = CMaTxOutIdW !C.MaTxOutId
+  | VMaTxOutIdW !V.MaTxOutId
+  deriving (Show)
+
+-- MaTxOut fields for a given TxOutTableType
+class (PersistEntity (MaTxOutTable a)) => MaTxOutFields (a :: TxOutTableType) where
+  type MaTxOutTable a :: Type
+  type MaTxOutIdFor a :: Type
+  maTxOutTxOutIdField :: EntityField (MaTxOutTable a) (TxOutIdFor a)
+  maTxOutIdentField :: EntityField (MaTxOutTable a) MultiAssetId
+  maTxOutQuantityField :: EntityField (MaTxOutTable a) DbWord64
+
+-- TxOutCore fields
+instance MaTxOutFields 'TxOutCore where
+  type MaTxOutTable 'TxOutCore = C.MaTxOut
+  type MaTxOutIdFor 'TxOutCore = C.MaTxOutId
+  maTxOutTxOutIdField = C.MaTxOutTxOutId
+  maTxOutIdentField = C.MaTxOutIdent
+  maTxOutQuantityField = C.MaTxOutQuantity
+
+-- TxOutVariantAddress fields
+instance MaTxOutFields 'TxOutVariantAddress where
+  type MaTxOutTable 'TxOutVariantAddress = V.MaTxOut
+  type MaTxOutIdFor 'TxOutVariantAddress = V.MaTxOutId
+  maTxOutTxOutIdField = V.MaTxOutTxOutId
+  maTxOutIdentField = V.MaTxOutIdent
+  maTxOutQuantityField = V.MaTxOutQuantity
+
+-- | UtxoQueryResult which has utxoAddress that can come from Core or Variant TxOut
+data UtxoQueryResult = UtxoQueryResult
+  { utxoTxOutW :: TxOutW
+  , utxoAddress :: Text
+  , utxoTxHash :: ByteString
+  }
+
+--------------------------------------------------------------------------------
+-- CollateralTxOut fields for a given TxOutTableType
+--------------------------------------------------------------------------------
+data CollateralTxOutW
+  = CCollateralTxOutW !C.CollateralTxOut
+  | VCollateralTxOutW !V.CollateralTxOut
+  deriving (Show)
+
+-- | A wrapper for TxOutId
+data CollateralTxOutIdW
+  = CCollateralTxOutIdW !C.CollateralTxOutId
+  | VCollateralTxOutIdW !V.CollateralTxOutId
+  deriving (Show)
+
+class (PersistEntity (CollateralTxOutTable a)) => CollateralTxOutFields (a :: TxOutTableType) where
+  type CollateralTxOutTable a :: Type
+  type CollateralTxOutIdFor a :: Type
+  collateralTxOutIdField :: EntityField (CollateralTxOutTable a) (CollateralTxOutIdFor a)
+  collateralTxOutTxIdField :: EntityField (TxOutTable a) TxId
+  collateralTxOutIndexField :: EntityField (TxOutTable a) DbWord64
+  collateralTxOutAddressField :: EntityField (TxOutTable a) Text
+  collateralTxOutAddressHasScriptField :: EntityField (TxOutTable a) Bool
 
 --------------------------------------------------------------------------------
 -- Helper functions

--- a/cardano-db/src/Cardano/Db/Schema/BaseSchema.hs
+++ b/cardano-db/src/Cardano/Db/Schema/BaseSchema.hs
@@ -148,19 +148,6 @@ share
     scriptHash          ByteString Maybe    sqltype=hash28type
     UniqueStakeAddress  hashRaw
 
-  CollateralTxOut
-    txId                TxId                noreference     -- This type is the primary key for the 'tx' table.
-    index               Word64              sqltype=txindex
-    address             Text
-    addressHasScript    Bool
-    paymentCred         ByteString Maybe    sqltype=hash28type
-    stakeAddressId      StakeAddressId Maybe noreference
-    value               DbLovelace          sqltype=lovelace
-    dataHash            ByteString Maybe    sqltype=hash32type
-    multiAssetsDescr    Text
-    inlineDatumId       DatumId Maybe       noreference
-    referenceScriptId   ScriptId Maybe      noreference
-
   TxIn
     txInId              TxId                noreference     -- The transaction where this is used as an input.
     txOutId             TxId                noreference         -- The transaction where this was created as an output.
@@ -834,20 +821,6 @@ schemaDocs =
       StakeAddressHashRaw # "The raw bytes of the stake address hash."
       StakeAddressView # "The Bech32 encoded version of the stake address."
       StakeAddressScriptHash # "The script hash, in case this address is locked by a script."
-
-    CollateralTxOut --^ do
-      "A table for transaction collateral outputs. New in v13."
-      CollateralTxOutTxId # "The Tx table index of the transaction that contains this transaction output."
-      CollateralTxOutIndex # "The index of this transaction output with the transaction."
-      CollateralTxOutAddress # "The human readable encoding of the output address. Will be Base58 for Byron era addresses and Bech32 for Shelley era."
-      CollateralTxOutAddressHasScript # "Flag which shows if this address is locked by a script."
-      CollateralTxOutPaymentCred # "The payment credential part of the Shelley address. (NULL for Byron addresses). For a script-locked address, this is the script hash."
-      CollateralTxOutStakeAddressId # "The StakeAddress table index for the stake address part of the Shelley address. (NULL for Byron addresses)."
-      CollateralTxOutValue # "The output value (in Lovelace) of the transaction output."
-      CollateralTxOutDataHash # "The hash of the transaction output datum. (NULL for Txs without scripts)."
-      CollateralTxOutMultiAssetsDescr # "This is a description of the multiassets in collateral output. Since the output is not really created, we don't need to add them in separate tables."
-      CollateralTxOutInlineDatumId # "The inline datum of the output, if it has one. New in v13."
-      CollateralTxOutReferenceScriptId # "The reference script of the output, if it has one. New in v13."
 
     TxIn --^ do
       "A table for transaction inputs."

--- a/cardano-db/src/Cardano/Db/Schema/Core/TxOut.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Core/TxOut.hs
@@ -35,7 +35,7 @@ share
   ]
   [persistLowerCase|
 ----------------------------------------------
--- Bassic Address TxOut
+-- Core TxOut
 ----------------------------------------------
   TxOut
     address             Text
@@ -50,6 +50,23 @@ share
     txId                TxId                noreference
     value               DbLovelace          sqltype=lovelace
     UniqueTxout         txId index          -- The (tx_id, index) pair must be unique.
+
+----------------------------------------------
+-- Core CollateralTxOut
+----------------------------------------------
+  CollateralTxOut
+    txId                TxId                noreference     -- This type is the primary key for the 'tx' table.
+    index               Word64              sqltype=txindex
+    address             Text
+    addressHasScript    Bool
+    paymentCred         ByteString Maybe    sqltype=hash28type
+    stakeAddressId      StakeAddressId Maybe noreference
+    value               DbLovelace          sqltype=lovelace
+    dataHash            ByteString Maybe    sqltype=hash32type
+    multiAssetsDescr    Text
+    inlineDatumId       DatumId Maybe       noreference
+    referenceScriptId   ScriptId Maybe      noreference
+    deriving Show
 
 ----------------------------------------------
 -- MultiAsset
@@ -79,6 +96,20 @@ schemaDocsTxOutCore =
       TxOutValue # "The output value (in Lovelace) of the transaction output."
 
       TxOutTxId # "The Tx table index of the transaction that contains this transaction output."
+
+    CollateralTxOut --^ do
+      "A table for transaction collateral outputs. New in v13."
+      CollateralTxOutTxId # "The Tx table index of the transaction that contains this transaction output."
+      CollateralTxOutIndex # "The index of this transaction output with the transaction."
+      CollateralTxOutAddress # "The human readable encoding of the output address. Will be Base58 for Byron era addresses and Bech32 for Shelley era."
+      CollateralTxOutAddressHasScript # "Flag which shows if this address is locked by a script."
+      CollateralTxOutPaymentCred # "The payment credential part of the Shelley address. (NULL for Byron addresses). For a script-locked address, this is the script hash."
+      CollateralTxOutStakeAddressId # "The StakeAddress table index for the stake address part of the Shelley address. (NULL for Byron addresses)."
+      CollateralTxOutValue # "The output value (in Lovelace) of the transaction output."
+      CollateralTxOutDataHash # "The hash of the transaction output datum. (NULL for Txs without scripts)."
+      CollateralTxOutMultiAssetsDescr # "This is a description of the multiassets in collateral output. Since the output is not really created, we don't need to add them in separate tables."
+      CollateralTxOutInlineDatumId # "The inline datum of the output, if it has one. New in v13."
+      CollateralTxOutReferenceScriptId # "The reference script of the output, if it has one. New in v13."
 
     MaTxOut --^ do
       "A table containing Multi-Asset transaction outputs."

--- a/cardano-db/src/Cardano/Db/Schema/Variant/TxOut.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Variant/TxOut.hs
@@ -44,9 +44,22 @@ share
     index               Word64              sqltype=txindex
     inlineDatumId       DatumId Maybe       noreference
     referenceScriptId   ScriptId Maybe      noreference
+    stakeAddressId      StakeAddressId Maybe noreference
     txId                TxId                noreference
     value               DbLovelace          sqltype=lovelace
     UniqueTxout         txId index          -- The (tx_id, index) pair must be unique.
+
+  CollateralTxOut
+    txId                TxId                noreference     -- This type is the primary key for the 'tx' table.
+    index               Word64              sqltype=txindex
+    addressId           AddressId
+    stakeAddressId      StakeAddressId Maybe noreference
+    value               DbLovelace          sqltype=lovelace
+    dataHash            ByteString Maybe    sqltype=hash32type
+    multiAssetsDescr    Text
+    inlineDatumId       DatumId Maybe       noreference
+    referenceScriptId   ScriptId Maybe      noreference
+    deriving Show
 
   Address
     address             Text
@@ -70,7 +83,7 @@ schemaDocsTxOutVariant =
   document entityDefsTxOutVariant $ do
     TxOut --^ do
       "A table for transaction outputs."
-      TxOutAddressId # "The human readable encoding of the output address. It is Base58 for Byron era addresses and Bech32 for Shelley era."
+      TxOutAddressId # "The Address table index for the output address."
       TxOutConsumedByTxId # "The Tx table index of the transaction that consumes this transaction output. Not populated by default, can be activated via tx-out configs."
       TxOutDataHash # "The hash of the transaction output datum. (NULL for Txs without scripts)."
       TxOutIndex # "The index of this transaction output with the transaction."
@@ -78,6 +91,18 @@ schemaDocsTxOutVariant =
       TxOutReferenceScriptId # "The reference script of the output, if it has one. New in v13."
       TxOutValue # "The output value (in Lovelace) of the transaction output."
       TxOutTxId # "The Tx table index of the transaction that contains this transaction output."
+
+    CollateralTxOut --^ do
+      "A table for transaction collateral outputs. New in v13."
+      CollateralTxOutTxId # "The Address table index for the output address."
+      CollateralTxOutIndex # "The index of this transaction output with the transaction."
+      CollateralTxOutAddressId # "The human readable encoding of the output address. Will be Base58 for Byron era addresses and Bech32 for Shelley era."
+      CollateralTxOutStakeAddressId # "The StakeAddress table index for the stake address part of the Shelley address. (NULL for Byron addresses)."
+      CollateralTxOutValue # "The output value (in Lovelace) of the transaction output."
+      CollateralTxOutDataHash # "The hash of the transaction output datum. (NULL for Txs without scripts)."
+      CollateralTxOutMultiAssetsDescr # "This is a description of the multiassets in collateral output. Since the output is not really created, we don't need to add them in separate tables."
+      CollateralTxOutInlineDatumId # "The inline datum of the output, if it has one. New in v13."
+      CollateralTxOutReferenceScriptId # "The reference script of the output, if it has one. New in v13."
 
     Address --^ do
       "A table for addresses that appear in outputs."

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -297,8 +297,12 @@ Key changes in the variant representation:
    - Centralizes address information that was previously duplicated across multiple TxOuts
 
 2. Modified `tx_out` table:
-   - Replaces `address`, `address_has_script`, and `payment_cred` fields with a single `address_id` field
-   - `addressId` references the new `Address` table
+   - Remove `address`, `address_has_script`, and `payment_cred`.
+   - Add `address_id` references the new `Address` table
+
+3. Modified `collateral_tx_out` table
+   - Remove `address`, `address_has_script`, and `payment_cred`.
+   - Add `address_id` references the new `Address` table
  
 The address table can only be used on an empty database due to the schema restructuring which would cause data loss.
 

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,6 +1,6 @@
 # Schema Documentation for cardano-db-sync
 
-Schema version: 13.5.0.2 (from branch **1333-new-AddressDetail-table** which may not accurately reflect the version number)
+Schema version: 13.5.0.2 (from branch **1870-variant-collateral-txout** which may not accurately reflect the version number)
 **Note:** This file is auto-generated from the documentation in cardano-db/src/Cardano/Db/Schema/BaseSchema.hs by the command `cabal run -- gen-schema-docs doc/schema.md`. This document should only be updated during the release process and updated on the release branch.
 
 ### `schema_version`
@@ -124,27 +124,6 @@ A table of unique stake addresses. Can be an actual address or a script hash.  T
 | `hash_raw` | addr29type | The raw bytes of the stake address hash. |
 | `view` | string | The Bech32 encoded version of the stake address. |
 | `script_hash` | hash28type | The script hash, in case this address is locked by a script. |
-
-### `collateral_tx_out`
-
-A table for transaction collateral outputs. New in v13.
-
-* Primary Id: `id`
-
-| Column name | Type | Description |
-|-|-|-|
-| `id` | integer (64) |  |
-| `tx_id` | integer (64) | The Tx table index of the transaction that contains this transaction output. |
-| `index` | txindex | The index of this transaction output with the transaction. |
-| `address` | string | The human readable encoding of the output address. Will be Base58 for Byron era addresses and Bech32 for Shelley era. |
-| `address_has_script` | boolean | Flag which shows if this address is locked by a script. |
-| `payment_cred` | hash28type | The payment credential part of the Shelley address. (NULL for Byron addresses). For a script-locked address, this is the script hash. |
-| `stake_address_id` | integer (64) | The StakeAddress table index for the stake address part of the Shelley address. (NULL for Byron addresses). |
-| `value` | lovelace | The output value (in Lovelace) of the transaction output. |
-| `data_hash` | hash32type | The hash of the transaction output datum. (NULL for Txs without scripts). |
-| `multi_assets_descr` | string | This is a description of the multiassets in collateral output. Since the output is not really created, we don't need to add them in separate tables. |
-| `inline_datum_id` | integer (64) | The inline datum of the output, if it has one. New in v13. |
-| `reference_script_id` | integer (64) | The reference script of the output, if it has one. New in v13. |
 
 ### `tx_in`
 
@@ -1187,6 +1166,27 @@ A table for transaction outputs.
 | `tx_id` | integer (64) | The Tx table index of the transaction that contains this transaction output. |
 | `value` | lovelace | The output value (in Lovelace) of the transaction output. |
 
+### `collateral_tx_out`
+
+A table for transaction collateral outputs. New in v13.
+
+* Primary Id: `id`
+
+| Column name | Type | Description |
+|-|-|-|
+| `id` | integer (64) |  |
+| `tx_id` | integer (64) | The Tx table index of the transaction that contains this transaction output. |
+| `index` | txindex | The index of this transaction output with the transaction. |
+| `address` | string | The human readable encoding of the output address. Will be Base58 for Byron era addresses and Bech32 for Shelley era. |
+| `address_has_script` | boolean | Flag which shows if this address is locked by a script. |
+| `payment_cred` | hash28type | The payment credential part of the Shelley address. (NULL for Byron addresses). For a script-locked address, this is the script hash. |
+| `stake_address_id` | integer (64) | The StakeAddress table index for the stake address part of the Shelley address. (NULL for Byron addresses). |
+| `value` | lovelace | The output value (in Lovelace) of the transaction output. |
+| `data_hash` | hash32type | The hash of the transaction output datum. (NULL for Txs without scripts). |
+| `multi_assets_descr` | string | This is a description of the multiassets in collateral output. Since the output is not really created, we don't need to add them in separate tables. |
+| `inline_datum_id` | integer (64) | The inline datum of the output, if it has one. New in v13. |
+| `reference_script_id` | integer (64) | The reference script of the output, if it has one. New in v13. |
+
 ### `ma_tx_out`
 
 A table containing Multi-Asset transaction outputs.
@@ -1214,14 +1214,34 @@ A table for transaction outputs.
 | Column name | Type | Description |
 |-|-|-|
 | `id` | integer (64) |  |
-| `address_id` | integer (64) | The human readable encoding of the output address. It is Base58 for Byron era addresses and Bech32 for Shelley era. |
+| `address_id` | integer (64) | The Address table index for the output address. |
 | `consumed_by_tx_id` | integer (64) | The Tx table index of the transaction that consumes this transaction output. Not populated by default, can be activated via tx-out configs. |
 | `data_hash` | hash32type | The hash of the transaction output datum. (NULL for Txs without scripts). |
 | `index` | txindex | The index of this transaction output with the transaction. |
 | `inline_datum_id` | integer (64) | The inline datum of the output, if it has one. New in v13. |
 | `reference_script_id` | integer (64) | The reference script of the output, if it has one. New in v13. |
+| `stake_address_id` | integer (64) |  |
 | `tx_id` | integer (64) | The Tx table index of the transaction that contains this transaction output. |
 | `value` | lovelace | The output value (in Lovelace) of the transaction output. |
+
+### `collateral_tx_out`
+
+A table for transaction collateral outputs. New in v13.
+
+* Primary Id: `id`
+
+| Column name | Type | Description |
+|-|-|-|
+| `id` | integer (64) |  |
+| `tx_id` | integer (64) | The Address table index for the output address. |
+| `index` | txindex | The index of this transaction output with the transaction. |
+| `address_id` | integer (64) | The human readable encoding of the output address. Will be Base58 for Byron era addresses and Bech32 for Shelley era. |
+| `stake_address_id` | integer (64) | The StakeAddress table index for the stake address part of the Shelley address. (NULL for Byron addresses). |
+| `value` | lovelace | The output value (in Lovelace) of the transaction output. |
+| `data_hash` | hash32type | The hash of the transaction output datum. (NULL for Txs without scripts). |
+| `multi_assets_descr` | string | This is a description of the multiassets in collateral output. Since the output is not really created, we don't need to add them in separate tables. |
+| `inline_datum_id` | integer (64) | The inline datum of the output, if it has one. New in v13. |
+| `reference_script_id` | integer (64) | The reference script of the output, if it has one. New in v13. |
 
 ### `address`
 


### PR DESCRIPTION
# Description

This fixes https://github.com/IntersectMBO/cardano-db-sync/issues/1870

need to add some tests and update the docs to reflect these changes.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
