### PR TITLE
1843 - limit cache when close to tip

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Api/Ledger.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Ledger.hs
@@ -79,7 +79,11 @@ migrateBootstrapUTxO syncEnv = do
   where
     trce = getTrace syncEnv
 
-storeUTxOFromLedger :: (MonadBaseControl IO m, MonadIO m) => SyncEnv -> ExtLedgerState CardanoBlock -> ExceptT SyncNodeError (ReaderT SqlBackend m) ()
+storeUTxOFromLedger ::
+  (MonadBaseControl IO m, MonadIO m) =>
+  SyncEnv ->
+  ExtLedgerState CardanoBlock ->
+  ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 storeUTxOFromLedger env st = case ledgerState st of
   LedgerStateBabbage bts -> storeUTxO env (getUTxO bts)
   LedgerStateConway stc -> storeUTxO env (getUTxO stc)

--- a/cardano-db-sync/src/Cardano/DbSync/Cache.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache.hs
@@ -74,37 +74,38 @@ import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
 -- NOTE: Other tables are not cleaned up since they are not rollbacked.
 rollbackCache :: MonadIO m => CacheStatus -> DB.BlockId -> ReaderT SqlBackend m ()
 rollbackCache NoCache _ = pure ()
-rollbackCache (ActiveCache _ cache) blockId = do
+rollbackCache (ActiveCache cache) blockId = do
   liftIO $ do
     atomically $ writeTVar (cPrevBlock cache) Nothing
     atomically $ modifyTVar (cDatum cache) LRU.cleanup
     atomically $ modifyTVar (cTxIds cache) FIFO.cleanupCache
     void $ rollbackMapEpochInCache cache blockId
 
--- When syncing and we get within 2 minutes of the tip, we can optimise the caches
--- and set the flag to True on ActiveCache.
-optimiseCaches :: MonadIO m => CacheStatus -> ReaderT SqlBackend m CacheStatus
+-- | When syncing and we get within 2 minutes of the tip, we can optimise the caches
+-- and set the flag to True on ActiveCache.leaving the following caches as they are:
+-- cPools, cPrevBlock, Cstats, cEpoch
+optimiseCaches :: MonadIO m => CacheStatus -> ReaderT SqlBackend m ()
 optimiseCaches cache =
   case cache of
-    NoCache -> pure cache
-    ActiveCache True _ -> pure cache
-    ActiveCache False c -> do
-      liftIO $ do
-        -- empty caches not to be used anymore
-        atomically $ modifyTVar (cTxIds c) FIFO.cleanupCache
-        atomically $ writeTVar (cStake c) (StakeCache Map.empty (LRU.empty 0))
-        atomically $ modifyTVar (cDatum c) (LRU.optimise 0)
-        -- empty then limit the capacity of the cache
-        atomically $ writeTVar (cMultiAssets c) (LRU.empty 50000)
-        -- leaving the following caches as they are:
-        -- cPools, cPrevBlock, Cstats, cEpoch
-        pure $ ActiveCache True c
+    NoCache -> pure ()
+    ActiveCache c ->
+      withCacheOptimisationCheck c (pure ()) $
+        liftIO $ do
+          -- empty caches not to be used anymore
+          atomically $ modifyTVar (cTxIds c) FIFO.cleanupCache
+          atomically $ writeTVar (cStake c) (StakeCache Map.empty (LRU.empty 0))
+          atomically $ modifyTVar (cDatum c) (LRU.optimise 0)
+          -- empty then limit the capacity of the cache
+          atomically $ writeTVar (cMultiAssets c) (LRU.empty 50000)
+          -- set the flag to True
+          atomically $ writeTVar (cIsCacheOptimised c) True
+          pure ()
 
 getCacheStatistics :: CacheStatus -> IO CacheStatistics
 getCacheStatistics cs =
   case cs of
     NoCache -> pure initCacheStatistics
-    ActiveCache _ ci -> readTVarIO (cStats ci)
+    ActiveCache ci -> readTVarIO (cStats ci)
 
 queryOrInsertRewardAccount ::
   (MonadBaseControl IO m, MonadIO m) =>
@@ -170,34 +171,36 @@ queryStakeAddrWithCacheRetBs ::
 queryStakeAddrWithCacheRetBs _trce cache cacheUA ra@(Ledger.RewardAccount _ cred) = do
   let bs = Ledger.serialiseRewardAccount ra
   case cache of
-    NoCache -> mapLeft (,bs) <$> resolveStakeAddress bs
-    ActiveCache True _ -> mapLeft (,bs) <$> resolveStakeAddress bs
-    ActiveCache False ci -> do
-      stakeCache <- liftIO $ readTVarIO (cStake ci)
-      case queryStakeCache cred stakeCache of
-        Just (addrId, stakeCache') -> do
-          liftIO $ hitCreds (cStats ci)
-          case cacheUA of
-            EvictAndUpdateCache -> do
-              liftIO $ atomically $ writeTVar (cStake ci) $ deleteStakeCache cred stakeCache'
-              pure $ Right addrId
-            _other -> do
-              liftIO $ atomically $ writeTVar (cStake ci) stakeCache'
-              pure $ Right addrId
-        Nothing -> do
-          queryRes <- mapLeft (,bs) <$> resolveStakeAddress bs
-          liftIO $ missCreds (cStats ci)
-          case queryRes of
-            Left _ -> pure queryRes
-            Right stakeAddrsId -> do
-              let !stakeCache' = case cacheUA of
-                    UpdateCache -> stakeCache {scLruCache = LRU.insert cred stakeAddrsId (scLruCache stakeCache)}
-                    UpdateCacheStrong -> stakeCache {scStableCache = Map.insert cred stakeAddrsId (scStableCache stakeCache)}
-                    _ -> stakeCache
-              liftIO $
-                atomically $
-                  writeTVar (cStake ci) stakeCache'
-              pure $ Right stakeAddrsId
+    NoCache -> rsStkAdrrs bs
+    ActiveCache ci -> do
+      withCacheOptimisationCheck ci (rsStkAdrrs bs) $ do
+        stakeCache <- liftIO $ readTVarIO (cStake ci)
+        case queryStakeCache cred stakeCache of
+          Just (addrId, stakeCache') -> do
+            liftIO $ hitCreds (cStats ci)
+            case cacheUA of
+              EvictAndUpdateCache -> do
+                liftIO $ atomically $ writeTVar (cStake ci) $ deleteStakeCache cred stakeCache'
+                pure $ Right addrId
+              _other -> do
+                liftIO $ atomically $ writeTVar (cStake ci) stakeCache'
+                pure $ Right addrId
+          Nothing -> do
+            queryRes <- mapLeft (,bs) <$> resolveStakeAddress bs
+            liftIO $ missCreds (cStats ci)
+            case queryRes of
+              Left _ -> pure queryRes
+              Right stakeAddrsId -> do
+                let !stakeCache' = case cacheUA of
+                      UpdateCache -> stakeCache {scLruCache = LRU.insert cred stakeAddrsId (scLruCache stakeCache)}
+                      UpdateCacheStrong -> stakeCache {scStableCache = Map.insert cred stakeAddrsId (scStableCache stakeCache)}
+                      _otherwise -> stakeCache
+                liftIO $
+                  atomically $
+                    writeTVar (cStake ci) stakeCache'
+                pure $ Right stakeAddrsId
+  where
+    rsStkAdrrs bs = mapLeft (,bs) <$> resolveStakeAddress bs
 
 -- | True if it was found in LRU
 queryStakeCache :: StakeCred -> StakeCache -> Maybe (DB.StakeAddressId, StakeCache)
@@ -224,7 +227,7 @@ queryPoolKeyWithCache cache cacheUA hsh =
       case mPhId of
         Nothing -> pure $ Left (DB.DbLookupMessage "PoolKeyHash")
         Just phId -> pure $ Right phId
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       mp <- liftIO $ readTVarIO (cPools ci)
       case Map.lookup hsh mp of
         Just phId -> do
@@ -264,7 +267,7 @@ insertPoolKeyWithCache cache cacheUA pHash =
           { DB.poolHashHashRaw = Generic.unKeyHashRaw pHash
           , DB.poolHashView = Generic.unKeyHashView pHash
           }
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       mp <- liftIO $ readTVarIO (cPools ci)
       case Map.lookup pHash mp of
         Just phId -> do
@@ -327,23 +330,23 @@ queryMAWithCache ::
 queryMAWithCache cache policyId asset =
   case cache of
     NoCache -> queryDb
-    ActiveCache True _ -> queryDb
-    ActiveCache False ci -> do
-      mp <- liftIO $ readTVarIO (cMultiAssets ci)
-      case LRU.lookup (policyId, asset) mp of
-        Just (maId, mp') -> do
-          liftIO $ hitMAssets (cStats ci)
-          liftIO $ atomically $ writeTVar (cMultiAssets ci) mp'
-          pure $ Right maId
-        Nothing -> do
-          liftIO $ missMAssets (cStats ci)
-          -- miss. The lookup doesn't change the cache on a miss.
-          let !policyBs = Generic.unScriptHash $ policyID policyId
-          let !assetNameBs = Generic.unAssetName asset
-          maId <- maybe (Left (policyBs, assetNameBs)) Right <$> DB.queryMultiAssetId policyBs assetNameBs
-          whenRight maId $
-            liftIO . atomically . modifyTVar (cMultiAssets ci) . LRU.insert (policyId, asset)
-          pure maId
+    ActiveCache ci -> do
+      withCacheOptimisationCheck ci queryDb $ do
+        mp <- liftIO $ readTVarIO (cMultiAssets ci)
+        case LRU.lookup (policyId, asset) mp of
+          Just (maId, mp') -> do
+            liftIO $ hitMAssets (cStats ci)
+            liftIO $ atomically $ writeTVar (cMultiAssets ci) mp'
+            pure $ Right maId
+          Nothing -> do
+            liftIO $ missMAssets (cStats ci)
+            -- miss. The lookup doesn't change the cache on a miss.
+            let !policyBs = Generic.unScriptHash $ policyID policyId
+            let !assetNameBs = Generic.unAssetName asset
+            maId <- maybe (Left (policyBs, assetNameBs)) Right <$> DB.queryMultiAssetId policyBs assetNameBs
+            whenRight maId $
+              liftIO . atomically . modifyTVar (cMultiAssets ci) . LRU.insert (policyId, asset)
+            pure maId
   where
     queryDb = do
       let !policyBs = Generic.unScriptHash $ policyID policyId
@@ -359,7 +362,7 @@ queryPrevBlockWithCache ::
 queryPrevBlockWithCache msg cache hsh =
   case cache of
     NoCache -> liftLookupFail msg $ DB.queryBlockId hsh
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       mCachedPrev <- liftIO $ readTVarIO (cPrevBlock ci)
       case mCachedPrev of
         -- if the cached block matches the requested hash, we return its db id.
@@ -388,28 +391,28 @@ queryTxIdWithCache cache txIdLedger = do
   case cache of
     -- Direct database query if no cache.
     NoCache -> qTxHash
-    ActiveCache True _ -> qTxHash
-    ActiveCache False cacheInternal -> do
-      -- Read current cache state.
-      cacheTx <- liftIO $ readTVarIO (cTxIds cacheInternal)
+    ActiveCache ci ->
+      withCacheOptimisationCheck ci qTxHash $ do
+        -- Read current cache state.
+        cacheTx <- liftIO $ readTVarIO (cTxIds ci)
 
-      case FIFO.lookup txIdLedger cacheTx of
-        -- Cache hit, return the transaction ID.
-        Just txId -> do
-          liftIO $ hitTxIds (cStats cacheInternal)
-          pure $ Right txId
-        -- Cache miss.
-        Nothing -> do
-          eTxId <- qTxHash
-          liftIO $ missTxIds (cStats cacheInternal)
-          case eTxId of
-            Right txId -> do
-              -- Update cache.
-              liftIO $ atomically $ modifyTVar (cTxIds cacheInternal) $ FIFO.insert txIdLedger txId
-              -- Return ID after updating cache.
-              pure $ Right txId
-            -- Return lookup failure.
-            Left _ -> pure $ Left $ DB.DbLookupTxHash txHash
+        case FIFO.lookup txIdLedger cacheTx of
+          -- Cache hit, return the transaction ID.
+          Just txId -> do
+            liftIO $ hitTxIds (cStats ci)
+            pure $ Right txId
+          -- Cache miss.
+          Nothing -> do
+            eTxId <- qTxHash
+            liftIO $ missTxIds (cStats ci)
+            case eTxId of
+              Right txId -> do
+                -- Update cache.
+                liftIO $ atomically $ modifyTVar (cTxIds ci) $ FIFO.insert txIdLedger txId
+                -- Return ID after updating cache.
+                pure $ Right txId
+              -- Return lookup failure.
+              Left _ -> pure $ Left $ DB.DbLookupTxHash txHash
   where
     txHash = Generic.unTxHash txIdLedger
     qTxHash = DB.queryTxId txHash
@@ -420,7 +423,7 @@ tryUpdateCacheTx ::
   Ledger.TxId StandardCrypto ->
   DB.TxId ->
   m ()
-tryUpdateCacheTx (ActiveCache False ci) ledgerTxId txId =
+tryUpdateCacheTx (ActiveCache ci) ledgerTxId txId =
   liftIO $ atomically $ modifyTVar (cTxIds ci) $ FIFO.insert ledgerTxId txId
 tryUpdateCacheTx _ _ _ = pure ()
 
@@ -432,13 +435,13 @@ insertBlockAndCache ::
 insertBlockAndCache cache block =
   case cache of
     NoCache -> insBlck
-    ActiveCache True _ -> insBlck
-    ActiveCache False ci -> do
-      bid <- insBlck
-      liftIO $ do
-        missPrevBlock (cStats ci)
-        atomically $ writeTVar (cPrevBlock ci) $ Just (bid, DB.blockHash block)
-      pure bid
+    ActiveCache ci ->
+      withCacheOptimisationCheck ci insBlck $ do
+        bid <- insBlck
+        liftIO $ do
+          missPrevBlock (cStats ci)
+          atomically $ writeTVar (cPrevBlock ci) $ Just (bid, DB.blockHash block)
+        pure bid
   where
     insBlck = DB.insertBlock block
 
@@ -450,18 +453,18 @@ queryDatum ::
 queryDatum cache hsh = do
   case cache of
     NoCache -> queryDtm
-    ActiveCache True _ -> queryDtm
-    ActiveCache False ci -> do
-      mp <- liftIO $ readTVarIO (cDatum ci)
-      case LRU.lookup hsh mp of
-        Just (datumId, mp') -> do
-          liftIO $ hitDatum (cStats ci)
-          liftIO $ atomically $ writeTVar (cDatum ci) mp'
-          pure $ Just datumId
-        Nothing -> do
-          liftIO $ missDatum (cStats ci)
-          -- miss. The lookup doesn't change the cache on a miss.
-          queryDtm
+    ActiveCache ci -> do
+      withCacheOptimisationCheck ci queryDtm $ do
+        mp <- liftIO $ readTVarIO (cDatum ci)
+        case LRU.lookup hsh mp of
+          Just (datumId, mp') -> do
+            liftIO $ hitDatum (cStats ci)
+            liftIO $ atomically $ writeTVar (cDatum ci) mp'
+            pure $ Just datumId
+          Nothing -> do
+            liftIO $ missDatum (cStats ci)
+            -- miss. The lookup doesn't change the cache on a miss.
+            queryDtm
   where
     queryDtm = DB.queryDatum $ Generic.dataHashToBytes hsh
 
@@ -476,13 +479,25 @@ insertDatumAndCache cache hsh dt = do
   datumId <- DB.insertDatum dt
   case cache of
     NoCache -> pure datumId
-    ActiveCache True _ -> pure datumId
-    ActiveCache False ci -> do
-      liftIO $
-        atomically $
-          modifyTVar (cDatum ci) $
-            LRU.insert hsh datumId
-      pure datumId
+    ActiveCache ci ->
+      withCacheOptimisationCheck ci (pure datumId) $ do
+        liftIO $
+          atomically $
+            modifyTVar (cDatum ci) $
+              LRU.insert hsh datumId
+        pure datumId
+
+withCacheOptimisationCheck ::
+  MonadIO m =>
+  CacheInternal ->
+  m a -> -- Action to perform if cache is optimised
+  m a -> -- Action to perform if cache is not optimised
+  m a
+withCacheOptimisationCheck ci ifOptimised ifNotOptimised = do
+  isCachedOptimised <- liftIO $ readTVarIO (cIsCacheOptimised ci)
+  if isCachedOptimised
+    then ifOptimised
+    else ifNotOptimised
 
 -- Stakes
 hitCreds :: StrictTVar IO CacheStatistics -> IO ()

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
@@ -29,7 +29,7 @@ readCacheEpoch :: MonadIO m => CacheStatus -> m (Maybe CacheEpoch)
 readCacheEpoch cache =
   case cache of
     NoCache -> pure Nothing
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       cacheEpoch <- liftIO $ readTVarIO (cEpoch ci)
       pure $ Just cacheEpoch
 
@@ -37,7 +37,7 @@ readEpochBlockDiffFromCache :: MonadIO m => CacheStatus -> m (Maybe EpochBlockDi
 readEpochBlockDiffFromCache cache =
   case cache of
     NoCache -> pure Nothing
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       cE <- liftIO $ readTVarIO (cEpoch ci)
       case (ceMapEpoch cE, ceEpochBlockDiff cE) of
         (_, epochInternal) -> pure epochInternal
@@ -46,7 +46,7 @@ readLastMapEpochFromCache :: CacheStatus -> IO (Maybe DB.Epoch)
 readLastMapEpochFromCache cache =
   case cache of
     NoCache -> pure Nothing
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       cE <- readTVarIO (cEpoch ci)
       let mapEpoch = ceMapEpoch cE
       -- making sure db sync wasn't restarted on the last block in epoch
@@ -72,7 +72,7 @@ writeEpochBlockDiffToCache ::
 writeEpochBlockDiffToCache cache epCurrent =
   case cache of
     NoCache -> pure $ Left $ SNErrDefault "writeEpochBlockDiffToCache: Cache is NoCache"
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       cE <- liftIO $ readTVarIO (cEpoch ci)
       case (ceMapEpoch cE, ceEpochBlockDiff cE) of
         (epochLatest, _) -> writeToCache ci (CacheEpoch epochLatest (Just epCurrent))
@@ -94,7 +94,7 @@ writeToMapEpochCache syncEnv cache latestEpoch = do
           NoLedger nle -> getSecurityParameter $ nleProtocolInfo nle
   case cache of
     NoCache -> pure $ Left $ SNErrDefault "writeToMapEpochCache: Cache is NoCache"
-    ActiveCache _ ci -> do
+    ActiveCache ci -> do
       -- get EpochBlockDiff so we can use the BlockId we stored when inserting blocks
       epochInternalCE <- readEpochBlockDiffFromCache cache
       case epochInternalCE of

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
@@ -29,7 +29,7 @@ readCacheEpoch :: MonadIO m => CacheStatus -> m (Maybe CacheEpoch)
 readCacheEpoch cache =
   case cache of
     NoCache -> pure Nothing
-    ActiveCache ci -> do
+    ActiveCache _ ci -> do
       cacheEpoch <- liftIO $ readTVarIO (cEpoch ci)
       pure $ Just cacheEpoch
 
@@ -37,7 +37,7 @@ readEpochBlockDiffFromCache :: MonadIO m => CacheStatus -> m (Maybe EpochBlockDi
 readEpochBlockDiffFromCache cache =
   case cache of
     NoCache -> pure Nothing
-    ActiveCache ci -> do
+    ActiveCache _ ci -> do
       cE <- liftIO $ readTVarIO (cEpoch ci)
       case (ceMapEpoch cE, ceEpochBlockDiff cE) of
         (_, epochInternal) -> pure epochInternal
@@ -46,7 +46,7 @@ readLastMapEpochFromCache :: CacheStatus -> IO (Maybe DB.Epoch)
 readLastMapEpochFromCache cache =
   case cache of
     NoCache -> pure Nothing
-    ActiveCache ci -> do
+    ActiveCache _ ci -> do
       cE <- readTVarIO (cEpoch ci)
       let mapEpoch = ceMapEpoch cE
       -- making sure db sync wasn't restarted on the last block in epoch
@@ -72,7 +72,7 @@ writeEpochBlockDiffToCache ::
 writeEpochBlockDiffToCache cache epCurrent =
   case cache of
     NoCache -> pure $ Left $ SNErrDefault "writeEpochBlockDiffToCache: Cache is NoCache"
-    ActiveCache ci -> do
+    ActiveCache _ ci -> do
       cE <- liftIO $ readTVarIO (cEpoch ci)
       case (ceMapEpoch cE, ceEpochBlockDiff cE) of
         (epochLatest, _) -> writeToCache ci (CacheEpoch epochLatest (Just epCurrent))
@@ -94,7 +94,7 @@ writeToMapEpochCache syncEnv cache latestEpoch = do
           NoLedger nle -> getSecurityParameter $ nleProtocolInfo nle
   case cache of
     NoCache -> pure $ Left $ SNErrDefault "writeToMapEpochCache: Cache is NoCache"
-    ActiveCache ci -> do
+    ActiveCache _ ci -> do
       -- get EpochBlockDiff so we can use the BlockId we stored when inserting blocks
       epochInternalCE <- readEpochBlockDiffFromCache cache
       case epochInternalCE of

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/LRU.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/LRU.hs
@@ -5,6 +5,7 @@ module Cardano.DbSync.Cache.LRU (
   LRUCache (..),
   empty,
   cleanup,
+  optimise,
   trim,
   insert,
   fromList,
@@ -43,6 +44,14 @@ cleanup :: LRUCache k v -> LRUCache k v
 cleanup cache =
   cache
     { cTick = 0
+    , cQueue = OrdPSQ.empty
+    }
+
+optimise :: Word64 -> LRUCache k v -> LRUCache k v
+optimise capacity cache =
+  cache
+    { cCapacity = capacity
+    , cTick = 0
     , cQueue = OrdPSQ.empty
     }
 

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
@@ -60,13 +60,14 @@ data StakeCache = StakeCache
   , scLruCache :: !(LRUCache StakeCred DB.StakeAddressId)
   }
 
--- 'CacheStatus' enables functions in this module to be called even if the cache has not been initialized.
+-- | 'CacheStatus' enables functions in this module to be called even if the cache has not been initialized.
 -- This is used during genesis insertions, where the cache is not yet initiated, and when the user has disabled the cache functionality.
 data CacheStatus
   = NoCache
-  | -- | The Bool represents if we have surpassed being close to the tip of the chain.
-    -- this is used to optimise the caches from that point onwards.
-    ActiveCache !Bool !CacheInternal
+  | ActiveCache
+      !Bool
+      -- ^ The Bool represents if we have surpassed being close to the tip of the chain.
+      !CacheInternal
 
 data CacheAction
   = UpdateCache
@@ -130,7 +131,7 @@ data CacheEpoch = CacheEpoch
 
 textShowStats :: CacheStatus -> IO Text
 textShowStats NoCache = pure "NoCache"
-textShowStats (ActiveCache isCacheOptomised ic) = do
+textShowStats (ActiveCache isCacheOptimised ic) = do
   stats <- readTVarIO $ cStats ic
   stakeHashRaws <- readTVarIO (cStake ic)
   pools <- readTVarIO (cPools ic)
@@ -140,7 +141,7 @@ textShowStats (ActiveCache isCacheOptomised ic) = do
   pure $
     mconcat
       [ "\nCache Statistics:"
-      , "\n  Caches Optomised: " <> textShow isCacheOptomised
+      , "\n  Caches Optimised: " <> textShow isCacheOptimised
       , "\n  Stake Addresses: "
       , "cache sizes: "
       , textShow (Map.size $ scStableCache stakeHashRaws)

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Adjust.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Adjust.hs
@@ -89,7 +89,7 @@ deleteReward trce nw cache epochNo (cred, rwd) = do
         where_ (rwdDb ^. Db.RewardType ==. val (Generic.rewardSource rwd))
         where_ (rwdDb ^. Db.RewardSpendableEpoch ==. val (unEpochNo epochNo))
         where_ (rwdDb ^. Db.RewardPoolId ==. val poolId)
-    _ -> pure ()
+    _otherwise -> pure ()
 
 deleteOrphanedRewards :: MonadIO m => EpochNo -> [Db.StakeAddressId] -> ReaderT SqlBackend m ()
 deleteOrphanedRewards (EpochNo epochNo) xs =

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
@@ -65,8 +65,8 @@ insertBlockUniversal ::
   ApplyResult ->
   ReaderT SqlBackend m (Either SyncNodeError ())
 insertBlockUniversal syncEnv shouldLog withinTwoMins withinHalfHour blk details isMember applyResult = do
-  -- if we're syncing within 30 mins of the tip, we optomise the caches.
-  newCache <- if isSyncedWithinHalfHour details then optimiseCaches cache else pure cache
+  -- if we're syncing within 2 mins of the tip, we optimise the caches.
+  newCache <- if isSyncedWithintwoMinutes details then optimiseCaches cache else pure cache
   runExceptT $ do
     pbid <- case Generic.blkPreviousHash blk of
       Nothing -> liftLookupFail (renderErrorMessage (Generic.blkEra blk)) DB.queryGenesis -- this is for networks that fork from Byron on epoch 0.

--- a/cardano-db-sync/src/Cardano/DbSync/Fix/EpochStake.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Fix/EpochStake.hs
@@ -18,7 +18,11 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Strict.Maybe as Strict
 import Database.Persist.Sql (SqlBackend)
 
-migrateStakeDistr :: (MonadIO m, MonadBaseControl IO m) => SyncEnv -> Strict.Maybe CardanoLedgerState -> ExceptT SyncNodeError (ReaderT SqlBackend m) Bool
+migrateStakeDistr ::
+  (MonadIO m, MonadBaseControl IO m) =>
+  SyncEnv ->
+  Strict.Maybe CardanoLedgerState ->
+  ExceptT SyncNodeError (ReaderT SqlBackend m) Bool
 migrateStakeDistr env mcls =
   case (envLedgerEnv env, mcls) of
     (HasLedger lenv, Strict.Just cls) -> do

--- a/cardano-db-sync/src/Cardano/DbSync/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Util.hs
@@ -14,6 +14,7 @@ module Cardano.DbSync.Util (
   fmap3,
   getSyncStatus,
   isSyncedWithinSeconds,
+  isSyncedWithinHalfHour,
   liftedLogException,
   logActionDuration,
   logException,
@@ -75,9 +76,6 @@ cardanoBlockSlotNo = blockSlot
 fmap3 :: (Functor f, Functor g, Functor h) => (a -> b) -> f (g (h a)) -> f (g (h b))
 fmap3 = fmap . fmap . fmap
 
-getSyncStatus :: SlotDetails -> SyncState
-getSyncStatus sd = isSyncedWithinSeconds sd 120
-
 isSyncedWithinSeconds :: SlotDetails -> Word -> SyncState
 isSyncedWithinSeconds sd target =
   -- diffUTCTime returns seconds.
@@ -85,6 +83,12 @@ isSyncedWithinSeconds sd target =
    in if fromIntegral (abs secDiff) <= target
         then SyncFollowing
         else SyncLagging
+
+getSyncStatus :: SlotDetails -> SyncState
+getSyncStatus sd = isSyncedWithinSeconds sd 120
+
+isSyncedWithinHalfHour :: SlotDetails -> Bool
+isSyncedWithinHalfHour sd = isSyncedWithinSeconds sd 1800 == SyncFollowing
 
 textPrettyShow :: Show a => a -> Text
 textPrettyShow = Text.pack . ppShow

--- a/cardano-db-sync/src/Cardano/DbSync/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Util.hs
@@ -14,7 +14,7 @@ module Cardano.DbSync.Util (
   fmap3,
   getSyncStatus,
   isSyncedWithinSeconds,
-  isSyncedWithinHalfHour,
+  isSyncedWithintwoMinutes,
   liftedLogException,
   logActionDuration,
   logException,
@@ -87,8 +87,8 @@ isSyncedWithinSeconds sd target =
 getSyncStatus :: SlotDetails -> SyncState
 getSyncStatus sd = isSyncedWithinSeconds sd 120
 
-isSyncedWithinHalfHour :: SlotDetails -> Bool
-isSyncedWithinHalfHour sd = isSyncedWithinSeconds sd 1800 == SyncFollowing
+isSyncedWithintwoMinutes :: SlotDetails -> Bool
+isSyncedWithintwoMinutes sd = isSyncedWithinSeconds sd 120 == SyncFollowing
 
 textPrettyShow :: Show a => a -> Text
 textPrettyShow = Text.pack . ppShow


### PR DESCRIPTION
# Description

This fixes #1843 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
