### PR TITLE
1887 address table migration

### DIFF
--- a/cardano-db/src/Cardano/Db/Error.hs
+++ b/cardano-db/src/Cardano/Db/Error.hs
@@ -34,6 +34,8 @@ data LookupFail
   | DBMultipleGenesis
   | DBExtraMigration !String
   | DBPruneConsumed !String
+  | DBCreateAddress !String
+  | DBAddressMigration !String
   | DBRJsonbInSchema !String
   | DBTxOutVariant !String
   deriving (Eq, Generic)
@@ -55,7 +57,9 @@ instance Show LookupFail where
       DbMetaMultipleRows -> "Multiple rows in Meta table which should only contain one"
       DBMultipleGenesis -> "Multiple Genesis blocks found. These are blocks without an EpochNo"
       DBExtraMigration e -> "DBExtraMigration : " <> e
-      DBPruneConsumed e -> "DBExtraMigration" <> e
+      DBPruneConsumed e -> "DBPruneConsumed" <> e
+      DBCreateAddress e -> "DBCreateAddress" <> e
+      DBAddressMigration e -> "DBAddressMigration" <> e
       DBRJsonbInSchema e -> "DBRJsonbInSchema" <> e
       DBTxOutVariant e -> "DbTxOutVariant" <> e
 


### PR DESCRIPTION
# Description

this fixes #1887 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
