### PR TITLE
CI: Do not tag "latest" image latest on branch builds

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -61,10 +61,12 @@ jobs:
             docker-archive:./result \
             docker://ghcr.io/${REPO_OWNER}/cardano-db-sync:$IMAGE_TAG
 
-          # Also tag it as latest
-          skopeo copy \
-            docker-archive:./result \
-            docker://ghcr.io/${REPO_OWNER}/cardano-db-sync:latest
+          # If it's a tag build, also tag it as latest
+          if [[ "$GITHUB_REF_TYPE" = "tag" ]]; then
+            skopeo copy \
+              docker-archive:./result \
+              docker://ghcr.io/${REPO_OWNER}/cardano-db-sync:latest
+          fi
 
       - name: Upload ${{ github.actor }}/cardano-smash-server
         run: |
@@ -76,7 +78,9 @@ jobs:
             docker-archive:./result \
             docker://ghcr.io/${REPO_OWNER}/cardano-smash-server:$IMAGE_TAG
 
-          # Also tag it as latest
-          skopeo copy \
-            docker-archive:./result \
-            docker://ghcr.io/${REPO_OWNER}/cardano-smash-server:latest
+          # If it's a tag build, also tag it as latest
+          if [[ "$GITHUB_REF_TYPE" = "tag" ]]; then
+            skopeo copy \
+              docker-archive:./result \
+              docker://ghcr.io/${REPO_OWNER}/cardano-smash-server:latest
+          fi


### PR DESCRIPTION
# Description

Fixes #1876. We update the floating tag "latest" for all stable releases. For branch builds (testing), we do not want to update this.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
