### PR TITLE
build: Add `schema/` to release archive

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -411,7 +411,7 @@
               in
                 nixpkgs.runCommand name env
                   ''
-                    mkdir -p $out release
+                    mkdir -p $out release/bin
                     cd release
 
                     # Copy exes to intermediate dir
@@ -420,7 +420,16 @@
                       --remove-destination \
                       --verbose \
                       ${lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} \
-                       ./
+                       ./bin
+
+                    # Copy magrations to intermediate dir
+                    cp \
+                      --no-clobber \
+                      --remove-destination \
+                      --verbose \
+                      --recursive \
+                      ${./schema} \
+                      ./schema
 
                     # Rewrite libs on macos (from iohk-utils)
                     ${lib.optionalString


### PR DESCRIPTION
# Description

Fixes #1824. This restructures the release archive into:

```
+ bin
  - cardano-db-sync
  - <other exes>
+ schema
  - all <migration>.sql
```

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
