### PR TITLE
enh(docker): add some tools to the image

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -10,7 +10,7 @@
 , bashInteractive, cacert, cardano-cli, cardano-db-sync, cardano-db-tool
 , cardano-smash-server, coreutils, curl, findutils, getconf, glibcLocales
 , gnused, gnutar, gzip, jq, iana-etc, iproute, iputils, lib, libidn, libpqxx
-, postgresql_17, socat, utillinux
+, postgresql_17, socat, utillinux, gnugrep, less
 }:
 
 let
@@ -37,6 +37,7 @@ let
         findutils # GNU find
         getconf # get num cpus
         glibcLocales # Locale information for the GNU C Library
+        gnugrep # GNU grep
         gnused # GNU sed
         gnutar # GNU tar
         gzip # Gnuzip
@@ -51,6 +52,7 @@ let
         utillinux # System utilities for Linux
         cardano-cli # tool for interacting with cardano-node
         cardano-db-tool # utilities for creating database snapshots
+        less # Output pager for the psql command in interactive mode
       ];
     };
 


### PR DESCRIPTION
# Description

This adds the following packages to the docker image, useful for debugging
* `grep`: output filtering
* `less`: pager used by the `psql` command (it shows error `sh: line 1: less: command not found` without it if output has more than a few lines - for example when listing tables with `\d+`)

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations
No breaking change