### PR TITLE
Fix(CI): Pin cabal-the-library at <3.14

### DIFF
--- a/cardano-chain-gen/cardano-chain-gen.cabal
+++ b/cardano-chain-gen/cardano-chain-gen.cabal
@@ -19,7 +19,7 @@ extra-source-files:     CHANGELOG.md
 custom-setup
   setup-depends:
                         base
-                      , Cabal
+                      , Cabal >= 3.6 && <3.14
                       , bytestring
                       , cardano-crypto-class
                       , directory

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -20,7 +20,7 @@ extra-source-files:     CHANGELOG.md
 custom-setup
   setup-depends:
                         base
-                      , Cabal
+                      , Cabal >= 3.6 && <3.14
                       , bytestring
                       , cardano-crypto-class
                       , directory


### PR DESCRIPTION
# Description

Fixes #1947. The prerequisite was merging https://www.github.com/haskell/cabal/pull/10725 into stable-haskell/cabal

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
