### PR TITLE
Set redeemer fee to null if it is not null

### DIFF
--- a/cardano-db/src/Cardano/Db/Migration.hs
+++ b/cardano-db/src/Cardano/Db/Migration.hs
@@ -396,7 +396,7 @@ readStageFromFilename fn =
 noLedgerMigrations :: SqlBackend -> Trace IO Text -> IO ()
 noLedgerMigrations backend trce = do
   void $ runDbIohkLogging backend trce $ do
-    rawExecute "update redeemer set fee = null" []
+    rawExecute "update redeemer set fee = null where fee is not null" []
     rawExecute "delete from reward" []
     rawExecute "delete from epoch_stake" []
     rawExecute "delete from ada_pots" []


### PR DESCRIPTION
# Description

This avoids updating every row in the redeemer table when migrating to a no ledger schema, which speeds up startup from 7m 15s to 15s in our case.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [x] Resyncing and running the migrations provided will result in the same database semantically
