### PR TITLE
CI: Fix hlint workflow

### DIFF
--- a/.github/workflows/check-fourmolu.yml
+++ b/.github/workflows/check-fourmolu.yml
@@ -2,7 +2,7 @@ name: Check Fourmolu
 
 on:
   push: {}
-  merge_group: {}
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -15,16 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: sudo apt-get -y install libtinfo5
-
       - name: Set up HLint
-        uses: rwe/actions-hlint-setup@v1
+        uses: rwe/actions-hlint-setup@v1.0.3
         with:
           version: "3.2.7"
 
       - name: Run HLint
-        uses: rwe/actions-hlint-run@v2
+        uses: rwe/actions-hlint-run@v2.0.1
         with:
           path: "."
           fail-on: error

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up HLint
         uses: rwe/actions-hlint-setup@v1.0.3
         with:
-          version: "3.2.7"
+          version: "3.10"
 
       - name: Run HLint
         uses: rwe/actions-hlint-run@v2.0.1

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -2,7 +2,7 @@ name: Check HLint
 
 on:
   push: {}
-  merge_group: {}
+  pull_request: {}
 
 jobs:
   build:

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -26,4 +26,7 @@ jobs:
           path: "."
           fail-on: error
 
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install dependencies
+        run: sudo apt-get -y install libtinfo6
+
       - name: Set up HLint
         uses: rwe/actions-hlint-setup@v1.0.3
         with:

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up HLint
         uses: rwe/actions-hlint-setup@v1.0.3
         with:
-          version: "3.10"
+          version: "3.2.8"
 
       - name: Run HLint
         uses: rwe/actions-hlint-run@v2.0.1


### PR DESCRIPTION
# Description

This fixes the HLint CI job. It has been broken since the latest GitHub runner upgrade of `ubuntu-latest`

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
