### PR TITLE
Nix: Add devShells with profiling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -231,7 +231,6 @@
                   [ "../config/pgpass-mainnet" ];
                 packages.cardano-chain-gen.package.extraSrcFiles =
                   [ "../schema/*.sql" ];
-
               })
 
               ({ lib, config, ... }:
@@ -488,6 +487,17 @@
 
           in rec {
             checks = staticChecks;
+
+            devShells = 
+              let
+                mkVariantShell = compiler: variant: 
+                  lib.nameValuePair "profiled-${compiler}" v.shell;
+              in 
+                # "Profiled" devshell variants for each extra compiler
+                lib.mapAttrs' mkVariantShell project.profiled.projectVariants // {
+                  # A "profiled" variant shell for the default compiler
+                  profiled = project.profiled.shell;
+                };
 
             hydraJobs = callPackages inputs.iohkNix.utils.ciJobsAggregates {
               ciJobs = flake.hydraJobs;


### PR DESCRIPTION
# Description

Add the following devShells:

 * `profiled`
 * `profiled-ghc96`
 * `profiled-ghc98`
 * `profiled-ghc910`

This will include profiling for all the dependencies, but in order to make a profiled build you'll still need to add to cabal.project, eg:

```
ghc-options: -fprof-auto
```

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
