### PR TITLE
Patch postgresql-setup.sh

### DIFF
--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -192,6 +192,7 @@ function restore_snapshot {
 	tar xvf "$1" --directory "$tmp_dir"
 	if test -d "${tmp_dir}/db/" ; then
 	  # New pg_dump format
+	  lstate_gz_file=$(find "${tmp_dir}/" -iname "*.lstate.gz")
 	  if [ -n "${lstate_gz_file:-}" ] ; then
 	    lstate_file=$(basename "${lstate_gz_file}" | sed 's/.gz$//')
 	    gunzip --to-stdout "${lstate_gz_file}" > "$2/${lstate_file}"


### PR DESCRIPTION
# Description

Last update to this script accidentally seemed to have deleted an additional line that it wasnt supposed to. This resulted in lstate file not being restored in ledger-state directory, thereby - forcing a replay every time restore was done.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff
