### PR TITLE
Update index-states and remove old `allow-newer` stanzas

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-05-23T06:30:40Z
-  , cardano-haskell-packages 2025-05-16T20:03:45Z
+  , hackage.haskell.org 2025-06-26T20:35:31Z
+  , cardano-haskell-packages 2025-06-25T13:51:34Z
 
 packages:
   cardano-db
@@ -85,15 +85,9 @@ if impl (ghc >= 9.12)
     -- https://github.com/kapralVV/Unique/issues/11
     , Unique:hashable
 
-    -- https://github.com/Gabriella439/Haskell-Pipes-Safe-Library/pull/70
-    , pipes-safe:base
-
     -- https://github.com/haskellari/postgresql-simple/issues/152
     , postgresql-simple:base
     , postgresql-simple:template-haskell
-    
-    -- https://github.com/haskell-hvr/int-cast/issues/10
-    , int-cast:base
 
 -- The two following one-liners will cut off / restore the remainder of this file (for nix-shell users):
 -- when using the "cabal" wrapper script provided by nix-shell.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1748021818,
-        "narHash": "sha256-MwSc2+UaaOkLosZ6mtgJBoxeasgVp8+7HoEcGCyxjJY=",
+        "lastModified": 1750916280,
+        "narHash": "sha256-MJXQVDOxofqBdMES8rnV3k+5roojtRQFp9bikLSczm0=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "3a8a6e6a49b4fd3fc5c7778b9160ef4e54400a1e",
+        "rev": "fe0077935b7449995c7f583f198a28fac20620d1",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1748219218,
-        "narHash": "sha256-kKe1cGUGkwp/6704BTKlH4yWTL0wmZugofJU20PcIkA=",
+        "lastModified": 1750984033,
+        "narHash": "sha256-tZb2Ft86wgURfjyZ9T4Teo7CHU1kAaIDZPZPbuvf3Dg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d3c929097030b8405f983de59ea243018d7cf877",
+        "rev": "5eadab823fa138ba36abceb2e42a1c8ca88b7212",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

As per discription.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
