### PR TITLE
1986 - Fix duplicate pool stats

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
@@ -120,6 +120,7 @@ unitTests iom knownMigrations =
         , test "rollback stake address cache" Rollback.stakeAddressRollback
         , test "rollback change order of txs" Rollback.rollbackChangeTxOrder
         , test "rollback full tx" Rollback.rollbackFullTx
+        , test "pool stat rollback no duplicates" Rollback.poolStatRollback
         ]
     , testGroup
         "different configs"

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Rollback.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Rollback.hs
@@ -10,6 +10,7 @@ module Test.Cardano.Db.Mock.Unit.Conway.Rollback (
   stakeAddressRollback,
   rollbackChangeTxOrder,
   rollbackFullTx,
+  poolStatRollback,
 ) where
 
 import Cardano.Ledger.Coin (Coin (..))
@@ -25,9 +26,11 @@ import Ouroboros.Network.Block (blockPoint)
 import Test.Cardano.Db.Mock.Config
 import Test.Cardano.Db.Mock.Examples (mockBlock0, mockBlock1, mockBlock2)
 import Test.Cardano.Db.Mock.UnifiedApi
-import Test.Cardano.Db.Mock.Validate (assertBlockNoBackoff, assertTxCount)
-import Test.Tasty.HUnit (Assertion ())
+import Test.Cardano.Db.Mock.Validate (assertBlockNoBackoff, assertTxCount, runQuery)
+import Test.Tasty.HUnit (Assertion (), assertBool, assertEqual)
 import Prelude (last)
+import qualified Test.Cardano.Db.Mock.UnifiedApi as Api
+import qualified Cardano.Db as Db
 
 simpleRollback :: IOManager -> [(Text, Text)] -> Assertion
 simpleRollback =
@@ -291,3 +294,40 @@ rollbackFullTx =
     assertTxCount dbSync 14
   where
     testLabel = "conwayRollbackFullTx"
+
+poolStatRollback :: IOManager -> [(Text, Text)] -> Assertion
+poolStatRollback =
+  withFullConfigAndDropDB conwayConfigDir testLabel $ \interpreter mockServer dbSync -> do
+    startDBSync dbSync
+
+    -- Create pools and stake to generate pool stats
+    void $ Api.registerAllStakeCreds interpreter mockServer
+    void $ Api.fillEpochs interpreter mockServer 2
+
+    -- Create rollback point
+    blks <- Api.forgeAndSubmitBlocks interpreter mockServer 10
+    assertBlockNoBackoff dbSync (2 + length blks)
+
+    -- Check initial pool stat count
+    initialCount <- runQuery dbSync Db.queryPoolStatCount
+
+    -- Forge more blocks to create additional pool stats
+    void $ Api.fillEpochs interpreter mockServer 1
+    assertBlockNoBackoff dbSync (3 + length blks)
+
+    -- Verify pool stats increased
+    afterCount <- runQuery dbSync Db.queryPoolStatCount
+    assertBool "Pool stats should have increased" (afterCount > initialCount)
+
+    -- Rollback to previous point
+    atomically $ rollback mockServer (blockPoint $ last blks)
+    assertBlockNoBackoff dbSync (3 + length blks) -- Delayed rollback
+
+    -- Re-sync the same blocks - should not create duplicates
+    void $ Api.fillEpochs interpreter mockServer 1
+    finalCount <- runQuery dbSync Db.queryPoolStatCount
+
+    -- Verify count matches and no constraint violations occurred
+    assertEqual "Pool stat count should match after rollback" afterCount finalCount
+  where
+    testLabel = "conwayPoolStatRollback"

--- a/cardano-db/src/Cardano/Db/Operations/Query.hs
+++ b/cardano-db/src/Cardano/Db/Operations/Query.hs
@@ -69,6 +69,7 @@ module Cardano.Db.Operations.Query (
   queryReservedTicker,
   queryReservedTickers,
   queryDelistedPools,
+  queryPoolStatCount,
   queryOffChainPoolFetchError,
   existsDelistedPool,
   -- queries used in tools
@@ -921,6 +922,13 @@ queryDelistedPools = do
     delistedPool <- from $ table @DelistedPool
     pure $ delistedPool ^. DelistedPoolHashRaw
   pure $ unValue <$> res
+
+queryPoolStatCount :: MonadIO m => ReaderT SqlBackend m Word64
+queryPoolStatCount = do
+  res <- select $ do
+    _ <- from $ table @PoolStat
+    pure countRows
+  pure $ maybe 0 unValue (listToMaybe res)
 
 -- Returns also the metadata hash
 queryOffChainPoolFetchError :: MonadIO m => ByteString -> Maybe UTCTime -> ReaderT SqlBackend m [(OffChainPoolFetchError, ByteString)]

--- a/schema/migration-2-0045-20250708.sql
+++ b/schema/migration-2-0045-20250708.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 45 THEN
+    EXECUTE 'ALTER TABLE "pool_stat" ADD CONSTRAINT "unique_pool_stat_epoch"
+UNIQUE ("pool_hash_id", "epoch_no")' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
# Description

This fixes #1986

Due to complexity of partial entries and rollbacks it was just as performant to add a unique constraints to the table

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
