### PR TITLE
Optimise indexes and autoanalyze

### DIFF
--- a/cardano-db/src/Cardano/Db/Schema/Core/StakeDelegation.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Core/StakeDelegation.hs
@@ -265,7 +265,7 @@ data EpochStake = EpochStake
 type instance Key EpochStake = EpochStakeId
 
 instance DbInfo EpochStake where
-  uniqueFields _ = ["addr_id", "pool_id", "epoch_no"]
+  uniqueFields _ = ["epoch_no", "addr_id", "pool_id"]
   unnestParamTypes _ =
     [ ("addr_id", "bigint[]")
     , ("pool_id", "bigint[]")

--- a/schema/migration-2-0029-20240117.sql
+++ b/schema/migration-2-0029-20240117.sql
@@ -15,7 +15,7 @@ BEGIN
     EXECUTE 'ALTER TABLE "instant_reward" DROP COLUMN "earned_epoch"' ;
     EXECUTE 'ALTER TABLE "instant_reward" ADD COLUMN "earned_epoch" bigint NOT NULL GENERATED ALWAYS AS ((CASE WHEN spendable_epoch >= 1 then spendable_epoch-1 else 0 end)) STORED' ;
     EXECUTE 'ALTER TABLE "instant_reward" DROP COLUMN "pool_id"' ;
-    EXECUTE 'ALTER TABLE "instant_reward" ADD CONSTRAINT "unique_instant_reward" UNIQUE("addr_id","earned_epoch","type")' ;
+    EXECUTE 'ALTER TABLE "instant_reward" ADD CONSTRAINT "unique_instant_reward" UNIQUE("earned_epoch","addr_id","type")' ;
 
     EXECUTE 'DELETE FROM "reward" WHERE "pool_id" IS NULL' ;
     EXECUTE 'ALTER TABLE "reward" ALTER COLUMN "pool_id" SET NOT NULL' ;

--- a/schema/migration-4-0010-20260704.sql
+++ b/schema/migration-4-0010-20260704.sql
@@ -1,0 +1,10 @@
+
+CREATE INDEX IF NOT EXISTS idx_redeemer_tx_id ON redeemer(tx_id);
+CREATE INDEX IF NOT EXISTS idx_collateral_tx_out_tx_id ON collateral_tx_out(tx_id);
+CREATE INDEX IF NOT EXISTS idx_reference_tx_in_tx_in_id ON reference_tx_in(tx_in_id);
+CREATE INDEX IF NOT EXISTS idx_tx_metadata_tx_id_key ON tx_metadata(tx_id, key);
+DROP INDEX IF EXISTS idx_tx_metadata_tx_id;
+
+-- faster autoanalyze on heavy tables:
+ALTER TABLE public.block SET (autovacuum_analyze_scale_factor = 0.02, autovacuum_analyze_threshold = 5000);
+ALTER TABLE public.tx SET (autovacuum_analyze_scale_factor = 0.02, autovacuum_analyze_threshold = 5000);


### PR DESCRIPTION
# Description

* the unique index "unique_reward" needs proper order of columns with the epoch first so the hash tree has less depth. The size of the index drops from 30 GB to 20 GB on disk. This could also be checked for other compound indexes.
* added a few more indexes
* changed the threshold when "autoanalyze" kicks in on heavy tables. This leads to faster queries as the query planning is improved.

We have been benchmarking this on our ha db-sync setup on [BCA](https://blockchain-applied.com).

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
