### PR TITLE
Isolate validate checks and render errors cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - The `epoch` table is redesigned and replaced by a view; the in-memory cache that caused [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) is removed. Reads are unchanged.
 - Fix `pool_relay.port` overflow [#2135](https://github.com/IntersectMBO/cardano-db-sync/issues/2135); a startup migration repairs existing rows.
 - Add `--allow-private-offchain-urls` CLI flag enabling off-chain metadata fetches against private/loopback addresses. Intended for local-cluster testing only; off by default.
-- `cardano-db-tool validate` now runs every check and reports each result instead of aborting on the first failure, and `utxo-set` / `validate` errors show a readable message instead of dumping Haskell call-stack internals [#2163](https://github.com/IntersectMBO/cardano-db-sync/issues/2163).
 
 ## 13.7.1.0
 - Auto-repair `epoch.out_sum` / `epoch.fees` / `epoch.tx_count` / `epoch.blk_count` corruption introduced by issue [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) in 13.7.0.0 - 13.7.0.4. A startup migration recomputes every epoch row from the underlying `tx` / `block` tables and rewrites only the rows whose stored values disagree. Adds a one-time 5-15 minute delay on the first startup after upgrade on a mainnet-sized database; subsequent restarts and fresh syncs are unaffected. Operators on older release lines who do not upgrade can apply the same fix manually via [`scripts/fix-epoch-table.sql`](scripts/fix-epoch-table.sql).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - The `epoch` table is redesigned and replaced by a view; the in-memory cache that caused [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) is removed. Reads are unchanged.
 - Fix `pool_relay.port` overflow [#2135](https://github.com/IntersectMBO/cardano-db-sync/issues/2135); a startup migration repairs existing rows.
 - Add `--allow-private-offchain-urls` CLI flag enabling off-chain metadata fetches against private/loopback addresses. Intended for local-cluster testing only; off by default.
+- `cardano-db-tool validate` now runs every check and reports each result instead of aborting on the first failure, and `utxo-set` / `validate` errors show a readable message instead of dumping Haskell call-stack internals [#2163](https://github.com/IntersectMBO/cardano-db-sync/issues/2163).
 
 ## 13.7.1.0
 - Auto-repair `epoch.out_sum` / `epoch.fees` / `epoch.tx_count` / `epoch.blk_count` corruption introduced by issue [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) in 13.7.0.0 - 13.7.0.4. A startup migration recomputes every epoch row from the underlying `tx` / `block` tables and rewrites only the rows whose stored values disagree. Adds a one-time 5-15 minute delay on the first startup after upgrade on a mainnet-sized database; subsequent restarts and fresh syncs are unaffected. Operators on older release lines who do not upgrade can apply the same fix manually via [`scripts/fix-epoch-table.sql`](scripts/fix-epoch-table.sql).

--- a/cardano-db-tool/src/Cardano/DbTool/UtxoSet.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/UtxoSet.hs
@@ -10,6 +10,7 @@ import qualified Cardano.Db as DB
 import qualified Cardano.Db.Schema.Variants.TxOutAddress as VA
 import qualified Cardano.Db.Schema.Variants.TxOutCore as VC
 import Cardano.Prelude (textShow)
+import Control.Exception (displayException)
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -95,7 +96,7 @@ queryAtSlot txOutVariantType slotNo =
 reportSlotDate :: Word64 -> Either DB.DbLookupError UTCTime -> IO ()
 reportSlotDate slotNo eUtcTime = do
   case eUtcTime of
-    Left err -> putStrLn $ "\nDatabase not initialized or not accessible: " <> show err
+    Left err -> putStrLn $ "\n" <> displayException err
     Right time -> putStrLn $ "\nSlot number " ++ show slotNo ++ " will occur at " ++ show time ++ ".\n"
   exitSuccess
 

--- a/cardano-db-tool/src/Cardano/DbTool/Validate/BlockTxs.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validate/BlockTxs.hs
@@ -6,7 +6,6 @@ module Cardano.DbTool.Validate.BlockTxs (
 
 import qualified Cardano.Db as DB
 import Cardano.DbTool.Validate.Util
-import Control.Monad (forM_, when)
 import Data.Either (lefts)
 import Data.Word (Word64)
 import qualified System.Random as Random
@@ -38,18 +37,16 @@ validateBlockTxs epoch = do
   results <- DB.runDbStandaloneSilent $ mapM validateBlockCount blks
   case lefts results of
     [] -> putStrLn $ greenText "ok"
-    xs -> do
-      when (length xs > 1) $ putStrLn ""
-      forM_ xs $ \ve ->
-        putStrLn $
-          redText
-            ( "Failed on block no "
-                ++ show (veBlockNo ve)
-                ++ ": expected tx count of "
-                ++ show (veTxCountExpected ve)
-                ++ " but got "
-                ++ show (veTxCountActual ve)
-            )
+    xs -> error $ redText (concatMap (("\n" ++) . reportFailure) xs)
+  where
+    reportFailure :: ValidateError -> String
+    reportFailure ve =
+      "Failed on block no "
+        ++ show (veBlockNo ve)
+        ++ ": expected tx count of "
+        ++ show (veTxCountExpected ve)
+        ++ " but got "
+        ++ show (veTxCountActual ve)
 
 validateBlockCount :: (Word64, Word64) -> DB.DbM (Either ValidateError ())
 validateBlockCount (blockNo, txCountExpected) = do

--- a/cardano-db-tool/src/Cardano/DbTool/Validate/PoolOwner.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validate/PoolOwner.hs
@@ -11,4 +11,4 @@ validateAllPoolsHaveOwners = do
   count <- DB.runDbStandaloneSilent DB.queryPoolsWithoutOwners
   if count == 0
     then putStrLn $ greenText "ok"
-    else putStrLn $ redText ("Failed, " ++ show count ++ " pools are without owners.")
+    else error $ redText ("Failed, " ++ show count ++ " pools are without owners.")

--- a/cardano-db-tool/src/Cardano/DbTool/Validation.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validation.hs
@@ -15,7 +15,7 @@ import Cardano.DbTool.Validate.PoolOwner (validateAllPoolsHaveOwners)
 import Cardano.DbTool.Validate.TotalSupply (validateTotalSupplyDecreasing)
 import Cardano.DbTool.Validate.TxAccounting (validateTxAccounting)
 import Cardano.DbTool.Validate.Withdrawal (validateWithdrawals)
-import Control.Exception (ErrorCall (..), SomeException, displayException, fromException, try)
+import Control.Exception (ErrorCall (..), SomeAsyncException, SomeException, displayException, fromException, throwIO, try)
 import Control.Monad (unless)
 import System.Exit (exitFailure)
 
@@ -54,9 +54,12 @@ runCheck action = do
   result <- try action
   case result of
     Right () -> pure True
-    Left (e :: SomeException) -> do
-      putStrLn (renderCheckError e)
-      pure False
+    Left (e :: SomeException)
+      -- Let async exceptions (e.g. Ctrl-C) propagate instead of counting them as a failed check.
+      | Just (_ :: SomeAsyncException) <- fromException e -> throwIO e
+      | otherwise -> do
+          putStrLn (renderCheckError e)
+          pure False
 
 renderCheckError :: SomeException -> String
 renderCheckError e =

--- a/cardano-db-tool/src/Cardano/DbTool/Validation.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validation.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Cardano.DbTool.Validation (
   LedgerValidationParams (..),
   runDbValidation,
@@ -13,11 +15,15 @@ import Cardano.DbTool.Validate.PoolOwner (validateAllPoolsHaveOwners)
 import Cardano.DbTool.Validate.TotalSupply (validateTotalSupplyDecreasing)
 import Cardano.DbTool.Validate.TxAccounting (validateTxAccounting)
 import Cardano.DbTool.Validate.Withdrawal (validateWithdrawals)
+import Control.Exception (ErrorCall (..), SomeException, displayException, fromException, try)
+import Control.Monad (unless)
+import System.Exit (exitFailure)
 
 runDbValidation :: TxOutVariantType -> IO ()
 runDbValidation txOutVariantType = do
-  fastValidations
-  slowValidations txOutVariantType
+  fast <- fastValidations
+  slow <- slowValidations txOutVariantType
+  unless (and (fast <> slow)) exitFailure
 
 runLedgerValidation :: LedgerValidationParams -> TxOutVariantType -> IO ()
 runLedgerValidation =
@@ -25,15 +31,35 @@ runLedgerValidation =
 
 -- -------------------------------------------------------------------------------------------------
 
-fastValidations :: IO ()
-fastValidations = do
-  validateAllPoolsHaveOwners
-  validateBlockProperties
-  validateSumAdaPots
+fastValidations :: IO [Bool]
+fastValidations =
+  sequence
+    [ runCheck validateAllPoolsHaveOwners
+    , runCheck validateBlockProperties
+    , runCheck validateSumAdaPots
+    ]
 
-slowValidations :: TxOutVariantType -> IO ()
-slowValidations txOutVariantType = do
-  validateTxAccounting txOutVariantType
-  validateWithdrawals
-  validateEpochBlockTxs
-  validateTotalSupplyDecreasing txOutVariantType
+slowValidations :: TxOutVariantType -> IO [Bool]
+slowValidations txOutVariantType =
+  sequence
+    [ runCheck (validateTxAccounting txOutVariantType)
+    , runCheck validateWithdrawals
+    , runCheck validateEpochBlockTxs
+    , runCheck (validateTotalSupplyDecreasing txOutVariantType)
+    ]
+
+-- Run a single check, reporting a failure instead of aborting the remaining checks.
+runCheck :: IO () -> IO Bool
+runCheck action = do
+  result <- try action
+  case result of
+    Right () -> pure True
+    Left (e :: SomeException) -> do
+      putStrLn (renderCheckError e)
+      pure False
+
+renderCheckError :: SomeException -> String
+renderCheckError e =
+  case fromException e of
+    Just (ErrorCall msg) -> msg
+    Nothing -> displayException e

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -128,7 +128,8 @@ test-suite test
                         -Wunused-imports
                         -Wunused-packages
 
-  other-modules:        Test.Property.Cardano.Db.Migration
+  other-modules:        Test.Property.Cardano.Db.ErrorRender
+                        Test.Property.Cardano.Db.Migration
                         Test.Property.Cardano.Db.Types
                         Test.Property.Upstream
 

--- a/cardano-db/src/Cardano/Db/Error.hs
+++ b/cardano-db/src/Cardano/Db/Error.hs
@@ -17,7 +17,7 @@ module Cardano.Db.Error (
 
 import Cardano.BM.Trace (Trace, logError)
 import Cardano.Prelude (HasCallStack, MonadIO, SrcLoc (..), callStack, getCallStack, textShow, throwIO)
-import Control.Exception (Exception)
+import Control.Exception (Exception (..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Hasql.Session as HsqlSes
@@ -29,7 +29,8 @@ data DbLookupError = DbLookupError
   }
   deriving (Show, Eq)
 
-instance Exception DbLookupError
+instance Exception DbLookupError where
+  displayException = Text.unpack . dbLookupErrMsg
 
 -- | System errors for unexpected infrastructure failures (e.g., connection and query errors)
 data DbSessionError = DbSessionError
@@ -38,7 +39,9 @@ data DbSessionError = DbSessionError
   }
   deriving (Show, Eq)
 
-instance Exception DbSessionError
+instance Exception DbSessionError where
+  displayException e =
+    Text.unpack (dbSessionErrMsg e <> formatDbCallStack (dbSessionErrCallStack e))
 
 data DbCallStack = DbCallStack
   { dbCsFncName :: !String

--- a/cardano-db/test/Test/Property/Cardano/Db/ErrorRender.hs
+++ b/cardano-db/test/Test/Property/Cardano/Db/ErrorRender.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Property.Cardano.Db.ErrorRender (
+  tests,
+) where
+
+import Cardano.Db (DbCallStack (..), DbLookupError (..), DbSessionError (..))
+import Control.Exception (displayException)
+import Data.List (isInfixOf)
+import GHC.Stack (SrcLoc (..))
+import Hedgehog (Property, discover)
+import qualified Hedgehog as H
+
+-- A user-facing error must show its message, not the derived Show of the record
+-- (which leaks the DbCallStack / SrcLoc internals).
+
+prop_lookupErrorIsClean :: Property
+prop_lookupErrorIsClean =
+  H.withTests 1 . H.property $ do
+    let rendered = displayException (DbLookupError callStack "Slot not found for slot_no: 5")
+    H.assert ("Slot not found for slot_no: 5" `isInfixOf` rendered)
+    H.assert (not ("SrcLoc" `isInfixOf` rendered))
+    H.assert (not ("DbCallStack" `isInfixOf` rendered))
+
+prop_sessionErrorIsClean :: Property
+prop_sessionErrorIsClean =
+  H.withTests 1 . H.property $ do
+    let rendered = displayException (DbSessionError callStack "ResultError (RowError 0 6 UnexpectedNull)")
+    H.assert ("ResultError (RowError 0 6 UnexpectedNull)" `isInfixOf` rendered)
+    H.assert (not ("SrcLoc" `isInfixOf` rendered))
+    H.assert (not ("DbCallStack" `isInfixOf` rendered))
+
+callStack :: DbCallStack
+callStack =
+  DbCallStack
+    { dbCsFncName = "querySlotUtcTime"
+    , dbCsModule = "Cardano.DbTool.UtxoSet"
+    , dbCsFile = "src/Cardano/DbTool/UtxoSet.hs"
+    , dbCsLine = 93
+    , dbCsCallChain = [("caller", srcLoc)]
+    }
+
+srcLoc :: SrcLoc
+srcLoc =
+  SrcLoc
+    { srcLocPackage = "pkg"
+    , srcLocModule = "Cardano.DbTool.UtxoSet"
+    , srcLocFile = "src/Cardano/DbTool/UtxoSet.hs"
+    , srcLocStartLine = 93
+    , srcLocStartCol = 11
+    , srcLocEndLine = 93
+    , srcLocEndCol = 30
+    }
+
+tests :: IO Bool
+tests = H.checkParallel $$discover

--- a/cardano-db/test/Test/Property/Cardano/Db/ErrorRender.hs
+++ b/cardano-db/test/Test/Property/Cardano/Db/ErrorRender.hs
@@ -9,27 +9,28 @@ import Cardano.Db (DbCallStack (..), DbLookupError (..), DbSessionError (..))
 import Control.Exception (displayException)
 import Data.List (isInfixOf)
 import GHC.Stack (SrcLoc (..))
-import Hedgehog (Property, discover)
+import Hedgehog (Property, discover, (===))
 import qualified Hedgehog as H
 
 -- A user-facing error must show its message, not the derived Show of the record
--- (which leaks the DbCallStack / SrcLoc internals).
+-- (which leaks the DbCallStack / SrcLoc internals as raw record fields).
 
-prop_lookupErrorIsClean :: Property
-prop_lookupErrorIsClean =
-  H.withTests 1 . H.property $ do
-    let rendered = displayException (DbLookupError callStack "Slot not found for slot_no: 5")
-    H.assert ("Slot not found for slot_no: 5" `isInfixOf` rendered)
-    H.assert (not ("SrcLoc" `isInfixOf` rendered))
-    H.assert (not ("DbCallStack" `isInfixOf` rendered))
+-- A business lookup error is just its message: no call chain, no internals.
+prop_lookupErrorShowsMessageOnly :: Property
+prop_lookupErrorShowsMessageOnly =
+  H.withTests 1 . H.property $
+    displayException (DbLookupError callStack "Slot not found for slot_no: 5")
+      === "Slot not found for slot_no: 5"
 
-prop_sessionErrorIsClean :: Property
-prop_sessionErrorIsClean =
+-- A session (infrastructure) error keeps a readable call chain for diagnostics,
+-- but must not dump the derived Show of the DbCallStack / SrcLoc records.
+prop_sessionErrorHasNoRawRecordDump :: Property
+prop_sessionErrorHasNoRawRecordDump =
   H.withTests 1 . H.property $ do
     let rendered = displayException (DbSessionError callStack "ResultError (RowError 0 6 UnexpectedNull)")
     H.assert ("ResultError (RowError 0 6 UnexpectedNull)" `isInfixOf` rendered)
-    H.assert (not ("SrcLoc" `isInfixOf` rendered))
-    H.assert (not ("DbCallStack" `isInfixOf` rendered))
+    H.assert (not ("dbCsFncName" `isInfixOf` rendered))
+    H.assert (not ("srcLocFile" `isInfixOf` rendered))
 
 callStack :: DbCallStack
 callStack =

--- a/cardano-db/test/test.hs
+++ b/cardano-db/test/test.hs
@@ -1,4 +1,5 @@
 import Hedgehog.Main (defaultMain)
+import qualified Test.Property.Cardano.Db.ErrorRender
 import qualified Test.Property.Cardano.Db.Migration
 import qualified Test.Property.Cardano.Db.Types
 import qualified Test.Property.Upstream
@@ -7,6 +8,7 @@ main :: IO ()
 main =
   defaultMain
     [ Test.Property.Upstream.tests
+    , Test.Property.Cardano.Db.ErrorRender.tests
     , Test.Property.Cardano.Db.Migration.tests
     , Test.Property.Cardano.Db.Types.tests
     ]


### PR DESCRIPTION
Closes #2163.

`validate` sequenced its checks in plain IO, so the first check to fail or throw aborted the whole run and everything after it was skipped. In practice the TxAccounting check runs early, so a single failure there hid the withdrawal, epoch-block-txs and total-supply checks entirely. Each check now runs under `try`: a failure is reported, the run carries on to the remaining checks, and the command exits non-zero at the end if any of them failed.

The error rendering was the other half of the problem. `DbLookupError` and `DbSessionError` relied on their derived `Show` for display, so any surfaced error dumped the `DbCallStack` and `SrcLoc` records with package and file paths. On top of that, `utxo-set` reported a plain "slot has no block" as `Database not initialized or not accessible`, which points at the wrong thing entirely. Both error types now have a `displayException` that shows the message (with a readable call chain for the unexpected session errors), and `utxo-set` uses it, so a missing slot reads simply as `Slot not found for slot_no: N`.

The failing test comes first (`Test.Property.Cardano.Db.ErrorRender`, a pure Hedgehog check that `displayException` shows the message without the `DbCallStack` / `SrcLoc` internals), then the fix that turns it green. The isolation behaviour is verified end to end against a restored preprod database: `validate` now walks every check and prints each result before exiting non-zero, and `utxo-set --slot-no <missing>` prints the clean not-found line with no "not initialized" wording and no call-stack dump.

Note this is independent of the decoder crash in #2162. On a database where that bug is still present, `validate` now surfaces the `RowError` per check and keeps going rather than aborting, which is exactly the behaviour this change is meant to provide.
